### PR TITLE
CCDB-3709: Throw when failing to resume change stream

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -425,6 +425,8 @@ public final class MongoSourceTask extends SourceTask {
         if (resumeTokenNotFound(e)) {
           throw new ConnectException(
               "ResumeToken not found. Cannot create a change stream cursor", e);
+        } else {
+          throw new ConnectException("Failed to resume change stream", e);
         }
       }
       return null;


### PR DESCRIPTION
The error message received is:
```
Failed to resume change stream: Resume of change stream was not possible, as the resume point may no longer be in the oplog
```
Instead of logging and continuing despite not being able to resume change stream, always throw and stop the task.