### PR TITLE
Fix inferred schema naming convention

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ plugins {
 }
 
 group = "org.mongodb.kafka"
-version = "1.3.0"
+version = "1.3.1"
 description = "The official MongoDB Apache Kafka Connect Connector."
 
 java {

--- a/src/main/java/com/mongodb/kafka/connect/source/producer/InferSchemaAndValueProducer.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/producer/InferSchemaAndValueProducer.java
@@ -16,7 +16,7 @@
 
 package com.mongodb.kafka.connect.source.producer;
 
-import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.inferSchema;
+import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.inferDocumentSchema;
 
 import org.apache.kafka.connect.data.SchemaAndValue;
 
@@ -35,6 +35,6 @@ final class InferSchemaAndValueProducer implements SchemaAndValueProducer {
   @Override
   public SchemaAndValue get(final BsonDocument changeStreamDocument) {
     return bsonValueToSchemaAndValue.toSchemaAndValue(
-        inferSchema(changeStreamDocument), changeStreamDocument);
+        inferDocumentSchema(changeStreamDocument), changeStreamDocument);
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
@@ -16,8 +16,6 @@
 
 package com.mongodb.kafka.connect.source.schema;
 
-import static java.lang.String.format;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -34,9 +32,35 @@ public final class BsonDocumentToSchema {
 
   private static final String ID_FIELD = "_id";
   private static final Schema DEFAULT_INFER_SCHEMA_TYPE = Schema.OPTIONAL_STRING_SCHEMA;
-  public static final String SCHEMA_NAME_TEMPLATE = "inferred_name_%s";
+  public static final String DEFAULT_FIELD_NAME = "default";
 
-  public static Schema inferSchema(final BsonValue bsonValue) {
+  public static Schema inferDocumentSchema(final BsonDocument document) {
+    return createSchemaBuilder(DEFAULT_FIELD_NAME, document).required().build();
+  }
+
+  private static Schema inferDocumentSchema(final String fieldPath, final BsonDocument document) {
+    return createSchemaBuilder(fieldPath, document).optional().build();
+  }
+
+  private static SchemaBuilder createSchemaBuilder(
+      final String fieldPath, final BsonDocument document) {
+    SchemaBuilder builder = SchemaBuilder.struct();
+    builder.name(fieldPath);
+    if (document.containsKey(ID_FIELD)) {
+      builder.field(ID_FIELD, inferSchema(ID_FIELD, document.get(ID_FIELD)));
+    }
+    document.entrySet().stream()
+        .filter(kv -> !kv.getKey().equals(ID_FIELD))
+        .sorted(Map.Entry.comparingByKey())
+        .forEach(
+            kv ->
+                builder.field(
+                    kv.getKey(),
+                    inferSchema(createFieldPath(fieldPath, kv.getKey()), kv.getValue())));
+    return builder;
+  }
+
+  private static Schema inferSchema(final String fieldPath, final BsonValue bsonValue) {
     switch (bsonValue.getBsonType()) {
       case BOOLEAN:
         return Schema.OPTIONAL_BOOLEAN_SCHEMA;
@@ -54,26 +78,18 @@ public final class BsonDocumentToSchema {
       case TIMESTAMP:
         return Timestamp.builder().optional().build();
       case DOCUMENT:
-        SchemaBuilder builder = SchemaBuilder.struct();
-        BsonDocument document = bsonValue.asDocument();
-        if (document.containsKey(ID_FIELD)) {
-          builder.field(ID_FIELD, inferSchema(document.get(ID_FIELD)));
-        }
-        document.entrySet().stream()
-            .filter(kv -> !kv.getKey().equals(ID_FIELD))
-            .sorted(Map.Entry.comparingByKey())
-            .forEach(kv -> builder.field(kv.getKey(), inferSchema(kv.getValue())));
-        builder.name(generateName(builder));
-        return builder.optional().build();
+        return inferDocumentSchema(fieldPath, bsonValue.asDocument());
       case ARRAY:
         List<BsonValue> values = bsonValue.asArray().getValues();
         Schema firstItemSchema =
-            values.isEmpty() ? DEFAULT_INFER_SCHEMA_TYPE : inferSchema(values.get(0));
+            values.isEmpty() ? DEFAULT_INFER_SCHEMA_TYPE : inferSchema(fieldPath, values.get(0));
         if (values.isEmpty()
-            || values.stream().anyMatch(bv -> !Objects.equals(inferSchema(bv), firstItemSchema))) {
-          return SchemaBuilder.array(DEFAULT_INFER_SCHEMA_TYPE).optional().build();
+            || values.stream()
+            .anyMatch(bv -> !Objects.equals(inferSchema(fieldPath, bv), firstItemSchema))) {
+          return SchemaBuilder.array(DEFAULT_INFER_SCHEMA_TYPE).name(fieldPath).optional().build();
         }
-        return SchemaBuilder.array(inferSchema(bsonValue.asArray().getValues().get(0)))
+        return SchemaBuilder.array(inferSchema(fieldPath, bsonValue.asArray().getValues().get(0)))
+            .name(fieldPath)
             .optional()
             .build();
       case BINARY:
@@ -95,8 +111,12 @@ public final class BsonDocumentToSchema {
     }
   }
 
-  public static String generateName(final SchemaBuilder builder) {
-    return format(SCHEMA_NAME_TEMPLATE, Objects.hashCode(builder.build())).replace("-", "_");
+  private static String createFieldPath(final String fieldPath, final String fieldName) {
+    if (fieldPath.equals(DEFAULT_FIELD_NAME)) {
+      return fieldName;
+    } else {
+      return fieldPath + "_" + fieldName;
+    }
   }
 
   private BsonDocumentToSchema() {}

--- a/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
@@ -285,29 +285,6 @@ public class SchemaAndValueProducerTest {
         // Ensure the data length is truncated.
         () -> assertEquals(1071, ((byte[]) actual.value()).length),
         () -> assertEquals(CHANGE_STREAM_DOCUMENT, new RawBsonDocument((byte[]) actual.value())));
-
-    RawBsonDocument rawBsonDocument = RawBsonDocument.parse(CHANGE_STREAM_DOCUMENT_JSON);
-    SchemaAndValue rawSchemaValue = bsonSchemaAndValueProducer.get(rawBsonDocument);
-    assertAll(
-        "Assert schema and value matches for raw bson document",
-        () -> assertEquals(Schema.BYTES_SCHEMA.schema(), rawSchemaValue.schema()),
-        // Ensure the data length is truncated.
-        () -> assertEquals(1071, ((byte[]) rawSchemaValue.value()).length),
-        () ->
-            assertEquals(
-                CHANGE_STREAM_DOCUMENT, new RawBsonDocument((byte[]) rawSchemaValue.value())));
-
-    SchemaAndValue rawSchemaValueForSubDocument =
-        bsonSchemaAndValueProducer.get(rawBsonDocument.getDocument("fullDocument"));
-    assertAll(
-        "Assert schema and value matches for raw bson sub document",
-        () -> assertEquals(Schema.BYTES_SCHEMA.schema(), rawSchemaValueForSubDocument.schema()),
-        // Ensure the data length is truncated.
-        () -> assertEquals(615, ((byte[]) rawSchemaValueForSubDocument.value()).length),
-        () ->
-            assertEquals(
-                CHANGE_STREAM_DOCUMENT.getDocument("fullDocument"),
-                new RawBsonDocument((byte[]) rawSchemaValueForSubDocument.value())));
   }
 
   static Struct generateExpectedValue(final boolean simplified) {

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/SchemaUtils.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/SchemaUtils.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -57,6 +58,11 @@ public final class SchemaUtils {
       // Doing equals on Struct just tests instance equals and not the actual values
       return getStructData((Struct) value);
     }
+
+    if (value instanceof List<?>) {
+      // List values can contain Structs which need converting
+      return getListData((List<?>) value);
+    }
     return value;
   }
 
@@ -72,6 +78,10 @@ public final class SchemaUtils {
     List<Object> structValues = new ArrayList<>();
     value.schema().fields().forEach(f -> structValues.add(convertData(value.get(f))));
     return structValues;
+  }
+
+  private static List<?> getListData(final List<?> value) {
+    return value.stream().map(SchemaUtils::convertData).collect(Collectors.toList());
   }
 
   public static void assertSchemaEquals(final Schema expected, final Schema actual) {


### PR DESCRIPTION
The inferred schemas by MongoDb connector were reported to be backward incompatible after recent changes in SR: [https://github.com/confluentinc/schema-registry/pull/1775](https://github.com/confluentinc/schema-registry/pull/1775)

This PR mirrors the PR in MongoDb Repo: [https://github.com/mongodb/mongo-kafka/pull/66](https://github.com/mongodb/mongo-kafka/pull/66) which provides a fix to make the inferred schemas backward compatible.