### PR TITLE
RCCA-2833: Deprecate and add new aliases for error-handling config properties that conflict with framework properties of the same name

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
@@ -330,12 +330,10 @@ public class MongoSinkTopicConfig extends AbstractConfig {
 
   @SuppressWarnings("deprecated")
   private void logDeprecationWarnings() {
-    Map<String, String> deprecatedPropertiesWithReplacements = new HashMap<>();
-    deprecatedPropertiesWithReplacements.put(
-        LEGACY_ERRORS_TOLERANCE_CONFIG, ERRORS_TOLERANCE_CONFIG);
-    deprecatedPropertiesWithReplacements.put(
-        LEGACY_ERRORS_LOG_ENABLE_CONFIG, ERRORS_LOG_ENABLE_CONFIG);
-    ConfigHelper.logDeprecationWarnings(deprecatedPropertiesWithReplacements, originals());
+    ConfigHelper.logDeprecationWarnings(
+        LEGACY_ERRORS_TOLERANCE_CONFIG, ERRORS_TOLERANCE_CONFIG, originals());
+    ConfigHelper.logDeprecationWarnings(
+        LEGACY_ERRORS_LOG_ENABLE_CONFIG, ERRORS_LOG_ENABLE_CONFIG, originals());
   }
 
   static final ConfigDef BASE_CONFIG = createConfigDef();

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -29,7 +29,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.apache.kafka.common.config.ConfigDef.Width;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -354,14 +353,14 @@ public class MongoSourceConfig extends AbstractConfig {
 
   @SuppressWarnings("deprecated")
   private void logDeprecationWarnings() {
-    Map<String, String> deprecatedPropertiesWithReplacements = new HashMap<>();
-    deprecatedPropertiesWithReplacements.put(
-        LEGACY_ERRORS_TOLERANCE_CONFIG, ERRORS_TOLERANCE_CONFIG);
-    deprecatedPropertiesWithReplacements.put(
-        LEGACY_ERRORS_LOG_ENABLE_CONFIG, ERRORS_LOG_ENABLE_CONFIG);
-    deprecatedPropertiesWithReplacements.put(
-        LEGACY_ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_DOC, ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG);
-    ConfigHelper.logDeprecationWarnings(deprecatedPropertiesWithReplacements, originals());
+    ConfigHelper.logDeprecationWarnings(
+        LEGACY_ERRORS_TOLERANCE_CONFIG, ERRORS_TOLERANCE_CONFIG, originals());
+    ConfigHelper.logDeprecationWarnings(
+        LEGACY_ERRORS_LOG_ENABLE_CONFIG, ERRORS_LOG_ENABLE_CONFIG, originals());
+    ConfigHelper.logDeprecationWarnings(
+        LEGACY_ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_DOC,
+        ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG,
+        originals());
   }
 
   public ConnectionString getConnectionString() {

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -29,6 +29,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.apache.kafka.common.config.ConfigDef.Width;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -240,7 +241,7 @@ public class MongoSourceConfig extends AbstractConfig {
           + "in the `demo` database: `demo\\.a.*`";
   private static final String COPY_EXISTING_NAMESPACE_REGEX_DEFAULT = "";
 
-  public static final String ERRORS_TOLERANCE_CONFIG = "errors.tolerance";
+  public static final String ERRORS_TOLERANCE_CONFIG = "mongo.errors.tolerance";
   public static final String ERRORS_TOLERANCE_DISPLAY = "Error Tolerance";
   public static final ErrorTolerance ERRORS_TOLERANCE_DEFAULT = ErrorTolerance.NONE;
   public static final String ERRORS_TOLERANCE_DOC =
@@ -248,15 +249,29 @@ public class MongoSourceConfig extends AbstractConfig {
           + "and signals that any error will result in an immediate connector task failure; 'all' "
           + "changes the behavior to skip over problematic records.";
 
-  public static final String ERRORS_LOG_ENABLE_CONFIG = "errors.log.enable";
+  @Deprecated
+  // Deprecated as it conflicts with the property of the same name used by the Connect framework
+  public static final String LEGACY_ERRORS_TOLERANCE_CONFIG = "errors.tolerance";
+
+  public static final String LEGACY_ERRORS_TOLERANCE_DOC =
+      "Deprecated; use '" + ERRORS_TOLERANCE_CONFIG + "' instead.";
+
+  public static final String ERRORS_LOG_ENABLE_CONFIG = "mongo.errors.log.enable";
   public static final String ERRORS_LOG_ENABLE_DISPLAY = "Log Errors";
   public static final boolean ERRORS_LOG_ENABLE_DEFAULT = false;
   public static final String ERRORS_LOG_ENABLE_DOC =
       "If true, write each error and the details of the failed operation and problematic record "
           + "to the Connect application log. This is 'false' by default, so that only errors that are not tolerated are reported.";
 
+  @Deprecated
+  // Deprecated as it conflicts with the property of the same name used by the Connect framework
+  public static final String LEGACY_ERRORS_LOG_ENABLE_CONFIG = "errors.log.enable";
+
+  public static final String LEGACY_ERRORS_LOG_ENABLE_DOC =
+      "Deprecated; use '" + ERRORS_LOG_ENABLE_CONFIG + "' instead.";
+
   public static final String ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG =
-      "errors.deadletterqueue.topic.name";
+      "mongo.errors.deadletterqueue.topic.name";
   public static final String ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_DISPLAY =
       "Output errors to the dead letter queue";
   public static final String ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_DEFAULT = "";
@@ -265,6 +280,14 @@ public class MongoSourceConfig extends AbstractConfig {
           + "Stops poison messages when using schemas, any message will be outputted as extended json on the specified topic. "
           + "By default messages are not outputted to the dead letter queue. "
           + "Also requires `errors.tolerance=all`.";
+
+  @Deprecated
+  // Deprecated as it conflicts with the property of the same name used by the Connect framework
+  public static final String LEGACY_ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG =
+      "errors.deadletterqueue.topic.name";
+
+  public static final String LEGACY_ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_DOC =
+      "Deprecated; use '" + ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG + "' instead.";
 
   public static final String HEARTBEAT_INTERVAL_MS_CONFIG = "heartbeat.interval.ms";
   private static final String HEARTBEAT_INTERVAL_MS_DISPLAY = "Heartbeat interval";
@@ -317,6 +340,7 @@ public class MongoSourceConfig extends AbstractConfig {
 
   public MongoSourceConfig(final Map<?, ?> originals) {
     this(originals, true);
+    logDeprecationWarnings();
   }
 
   private MongoSourceConfig(final Map<?, ?> originals, final boolean validateAll) {
@@ -326,6 +350,18 @@ public class MongoSourceConfig extends AbstractConfig {
     if (validateAll) {
       INITIALIZERS.forEach(i -> i.accept(this));
     }
+  }
+
+  @SuppressWarnings("deprecated")
+  private void logDeprecationWarnings() {
+    Map<String, String> deprecatedPropertiesWithReplacements = new HashMap<>();
+    deprecatedPropertiesWithReplacements.put(
+        LEGACY_ERRORS_TOLERANCE_CONFIG, ERRORS_TOLERANCE_CONFIG);
+    deprecatedPropertiesWithReplacements.put(
+        LEGACY_ERRORS_LOG_ENABLE_CONFIG, ERRORS_LOG_ENABLE_CONFIG);
+    deprecatedPropertiesWithReplacements.put(
+        LEGACY_ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_DOC, ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG);
+    ConfigHelper.logDeprecationWarnings(deprecatedPropertiesWithReplacements, originals());
   }
 
   public ConnectionString getConnectionString() {
@@ -379,9 +415,33 @@ public class MongoSourceConfig extends AbstractConfig {
         .getJsonWriterSettings();
   }
 
+  @SuppressWarnings("deprecated")
   public boolean tolerateErrors() {
-    return ErrorTolerance.valueOf(getString(ERRORS_TOLERANCE_CONFIG).toUpperCase())
-        .equals(ErrorTolerance.ALL);
+    String errorsTolerance =
+        ConfigHelper.readPropertyWithDeprecatedFallback(
+            ERRORS_TOLERANCE_CONFIG,
+            LEGACY_ERRORS_TOLERANCE_CONFIG,
+            this,
+            AbstractConfig::getString);
+    return ErrorTolerance.valueOf(errorsTolerance.toUpperCase()).equals(ErrorTolerance.ALL);
+  }
+
+  @SuppressWarnings("deprecated")
+  public boolean logErrors() {
+    return ConfigHelper.readPropertyWithDeprecatedFallback(
+        ERRORS_LOG_ENABLE_CONFIG,
+        LEGACY_ERRORS_LOG_ENABLE_CONFIG,
+        this,
+        AbstractConfig::getBoolean);
+  }
+
+  @SuppressWarnings("deprecated")
+  public String getDlqTopic() {
+    return ConfigHelper.readPropertyWithDeprecatedFallback(
+        ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG,
+        LEGACY_ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG,
+        this,
+        AbstractConfig::getString);
   }
 
   private static ConfigDef createConfigDef() {
@@ -702,6 +762,17 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.SHORT,
         ERRORS_TOLERANCE_DISPLAY);
+    configDef.define(
+        LEGACY_ERRORS_TOLERANCE_CONFIG,
+        Type.STRING,
+        ERRORS_TOLERANCE_DEFAULT.value(),
+        Validators.EnumValidatorAndRecommender.in(ErrorTolerance.values()),
+        Importance.MEDIUM,
+        LEGACY_ERRORS_TOLERANCE_DOC,
+        group,
+        ++orderInGroup,
+        Width.SHORT,
+        ERRORS_TOLERANCE_DISPLAY);
 
     configDef.define(
         ERRORS_LOG_ENABLE_CONFIG,
@@ -713,6 +784,16 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.SHORT,
         ERRORS_LOG_ENABLE_DISPLAY);
+    configDef.define(
+        LEGACY_ERRORS_LOG_ENABLE_CONFIG,
+        Type.BOOLEAN,
+        ERRORS_LOG_ENABLE_DEFAULT,
+        Importance.MEDIUM,
+        LEGACY_ERRORS_LOG_ENABLE_DOC,
+        group,
+        ++orderInGroup,
+        Width.SHORT,
+        ERRORS_LOG_ENABLE_DISPLAY);
 
     configDef.define(
         ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG,
@@ -720,6 +801,16 @@ public class MongoSourceConfig extends AbstractConfig {
         ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_DEFAULT,
         Importance.MEDIUM,
         ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_DOC,
+        group,
+        ++orderInGroup,
+        Width.SHORT,
+        ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_DISPLAY);
+    configDef.define(
+        LEGACY_ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG,
+        Type.STRING,
+        ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_DEFAULT,
+        Importance.MEDIUM,
+        LEGACY_ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_DOC,
         group,
         ++orderInGroup,
         Width.SHORT,

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -20,8 +20,6 @@ import static com.mongodb.kafka.connect.source.MongoSourceConfig.COLLECTION_CONF
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.CONNECTION_URI_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COPY_EXISTING_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.DATABASE_CONFIG;
-import static com.mongodb.kafka.connect.source.MongoSourceConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
-import static com.mongodb.kafka.connect.source.MongoSourceConfig.ERRORS_LOG_ENABLE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.HEARTBEAT_INTERVAL_MS_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.HEARTBEAT_TOPIC_NAME_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_AWAIT_TIME_MS_CONFIG;
@@ -303,17 +301,17 @@ public final class MongoSourceTask extends SourceTask {
                   "Exception creating Source record for: Key=%s Value=%s",
                   keyDocument.toJson(), valueDocument.toJson());
       if (sourceConfig.tolerateErrors()) {
-        if (sourceConfig.getBoolean(ERRORS_LOG_ENABLE_CONFIG)) {
+        if (sourceConfig.logErrors()) {
           LOGGER.error(errorMessage.get(), e);
         }
-        if (sourceConfig.getString(ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG).isEmpty()) {
+        if (sourceConfig.getDlqTopic().isEmpty()) {
           return Optional.empty();
         }
         return Optional.of(
             new SourceRecord(
                 partition,
                 sourceOffset,
-                sourceConfig.getString(ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG),
+                sourceConfig.getDlqTopic(),
                 Schema.STRING_SCHEMA,
                 keyDocument.toJson(),
                 Schema.STRING_SCHEMA,

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
@@ -85,7 +85,7 @@ public final class BsonDocumentToSchema {
             values.isEmpty() ? DEFAULT_INFER_SCHEMA_TYPE : inferSchema(fieldPath, values.get(0));
         if (values.isEmpty()
             || values.stream()
-            .anyMatch(bv -> !Objects.equals(inferSchema(fieldPath, bv), firstItemSchema))) {
+                .anyMatch(bv -> !Objects.equals(inferSchema(fieldPath, bv), firstItemSchema))) {
           return SchemaBuilder.array(DEFAULT_INFER_SCHEMA_TYPE).name(fieldPath).optional().build();
         }
         return SchemaBuilder.array(inferSchema(fieldPath, bsonValue.asArray().getValues().get(0)))

--- a/src/main/java/com/mongodb/kafka/connect/util/ConfigHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/ConfigHelper.java
@@ -135,38 +135,37 @@ public final class ConfigHelper {
 
   @SuppressWarnings("deprecated")
   public static void logDeprecationWarnings(
-      Map<String, String> deprecatedPropertiesWithReplacements, Map<String, Object> originals) {
-    deprecatedPropertiesWithReplacements.forEach(
-        (deprecatedProperty, replacement) -> {
-          if (originals.containsKey(deprecatedProperty)) {
-            if (originals.containsKey(replacement)) {
-              LOGGER.info(
-                  "The property '{}' has been deprecated and will be removed in a future release in favor of the '{}' property, which if "
-                      + "specified will take precedence over the '{}' property. Since the '{}' property has already been specified in this "
-                      + "connector config, '{}' can be removed from the connector config safely.",
-                  deprecatedProperty,
-                  replacement,
-                  deprecatedProperty,
-                  replacement,
-                  deprecatedProperty);
-            } else {
-              LOGGER.warn(
-                  "The property '{}' has been deprecated and will be removed in a future release in favor of the '{}' property. Please update "
-                      + "the connector config to use the '{}' property in place of '{}'",
-                  deprecatedProperty,
-                  replacement,
-                  replacement,
-                  deprecatedProperty);
-            }
-          }
-        });
+      final String deprecatedProperty,
+      final String replacement,
+      final Map<String, Object> originals) {
+    if (originals.containsKey(deprecatedProperty)) {
+      if (originals.containsKey(replacement)) {
+        LOGGER.info(
+            "The property '{}' has been deprecated and will be removed in a future release in favor of the '{}' property, which if "
+                + "specified will take precedence over the '{}' property. Since the '{}' property has already been specified in this "
+                + "connector config, '{}' can be removed from the connector config safely.",
+            deprecatedProperty,
+            replacement,
+            deprecatedProperty,
+            replacement,
+            deprecatedProperty);
+      } else {
+        LOGGER.warn(
+            "The property '{}' has been deprecated and will be removed in a future release in favor of the '{}' property. Please update "
+                + "the connector config to use the '{}' property in place of '{}'",
+            deprecatedProperty,
+            replacement,
+            replacement,
+            deprecatedProperty);
+      }
+    }
   }
 
   public static <T> T readPropertyWithDeprecatedFallback(
-      String property,
-      String deprecatedFallback,
-      AbstractConfig config,
-      BiFunction<AbstractConfig, String, T> getter) {
+      final String property,
+      final String deprecatedFallback,
+      final AbstractConfig config,
+      final BiFunction<AbstractConfig, String, T> getter) {
     String propertyToRead =
         config.originals().containsKey(property) ? property : deprecatedFallback;
     return getter.apply(config, propertyToRead);

--- a/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
@@ -161,11 +161,11 @@ public class SchemaAndValueProducerTest {
             .field(
                 "arrayComplex",
                 SchemaBuilder.array(
-                    SchemaBuilder.struct()
-                        .field("a", Schema.OPTIONAL_INT32_SCHEMA)
-                        .name("arrayComplex_a")
-                        .optional()
-                        .build())
+                        SchemaBuilder.struct()
+                            .field("a", Schema.OPTIONAL_INT32_SCHEMA)
+                            .name("arrayComplex_a")
+                            .optional()
+                            .build())
                     .optional()
                     .name("arrayComplex")
                     .build())


### PR DESCRIPTION
### Problem

If the `errors.tolerance` property is set to `all` for this connector, it can lead to silently skipping invalid records (without sending them to a DLQ topic).

However, we can't set it to `none` without also changing the behavior of the Connect framework (which is to send failing records to the dead letter queue topic).

### Solution

Add new aliases that override the existing error-handling properties and have names that don't conflict with framework properties.

There's some additional legwork done here to log deprecation notices and enable the older properties if the new aliases aren't used so that we'll be in a good position to submit this change upstream.

### Release strategy

Merge first to our fork, create a v1.3.3 tag, deploy to cloud, verify that it works as expected, then open a PR to submit this change upstream to Mongo's repo.