### PR TITLE
[Escalation:4949] - Invisible configs crash C3 UI

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
@@ -88,8 +88,6 @@ public class MongoSinkConfig extends AbstractConfig {
 
   static final String PROVIDER_CONFIG = "provider";
 
-  static final List<String> INVISIBLE_CONFIGS = singletonList(TOPIC_OVERRIDE_CONFIG);
-
   private Map<String, String> originals;
   private final Optional<List<String>> topics;
   private final Optional<Pattern> topicsRegex;
@@ -195,12 +193,7 @@ public class MongoSinkConfig extends AbstractConfig {
           @SuppressWarnings("unchecked")
           public Map<String, ConfigValue> validateAll(final Map<String, String> props) {
             Map<String, ConfigValue> results = super.validateAll(props);
-            INVISIBLE_CONFIGS.forEach(
-                c -> {
-                  if (results.containsKey(c)) {
-                    results.get(c).visible(false);
-                  }
-                });
+
             // Don't validate child configs if the top level configs are broken
             if (results.values().stream().anyMatch((c) -> !c.errorMessages().isEmpty())) {
               return results;


### PR DESCRIPTION
LINK - https://confluentinc.atlassian.net/browse/ESCALATION-4949
Reverting a small change in connector.

Reason - C3 front-end vault is not able to process this config since it is invisible and crashes. 
A better fix would be to handle this better in front-end, but that would need another CP release.

Build Passing.
All Tests running.
Manually tested on Confluent platform 6.1, it does not crash anymore.