### PR TITLE
[Escalation:4949] - Invisible configs crash C3 UI

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
@@ -86,7 +86,6 @@ public class MongoSinkConfig extends AbstractConfig {
           + TOPICS_CONFIG
           + "' are overridable.";
 
-  static final List<String> IGNORED_CONFIGS = singletonList(TOPIC_OVERRIDE_CONFIG);
 
   private Map<String, String> originals;
   private final Optional<List<String>> topics;
@@ -193,7 +192,6 @@ public class MongoSinkConfig extends AbstractConfig {
           @SuppressWarnings("unchecked")
           public Map<String, ConfigValue> validateAll(final Map<String, String> props) {
             Map<String, ConfigValue> results = super.validateAll(props);
-            IGNORED_CONFIGS.forEach(c -> results.remove(c));
             // Don't validate child configs if the top level configs are broken
             if (results.values().stream().anyMatch((c) -> !c.errorMessages().isEmpty())) {
               return results;

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
@@ -172,7 +172,6 @@ class MongoSinkConfigTest {
     Set<String> expectedKeys = new HashSet<>(MongoSinkConfig.CONFIG.configKeys().keySet());
     expectedKeys.addAll(MongoSinkTopicConfig.CONFIG.configKeys().keySet());
     // Remove ignored configs
-    expectedKeys.removeAll(MongoSinkConfig.IGNORED_CONFIGS);
     expectedKeys.removeAll(MongoSinkTopicConfig.IGNORED_CONFIGS);
 
     // Added declared overrides


### PR DESCRIPTION
LINK - https://confluentinc.atlassian.net/browse/ESCALATION-4949
Reverting a small change in connector.

Reason - C3 front-end vault is not able to process this config since it is invisible and crashes.
A better fix would be to handle this better in front-end, but that would need another CP release.

Build Passing.
All Tests running.
Manually tested on Confluent platform 6.1, it does not crash anymore.