### PR TITLE
Set connection.uri to be a secret to prevent credentials leak

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
@@ -247,7 +247,7 @@ public class MongoSinkConfig extends AbstractConfig {
 
     configDef.define(
         CONNECTION_URI_CONFIG,
-        Type.STRING,
+        Type.PASSWORD,
         CONNECTION_URI_DEFAULT,
         errorCheckingValueValidator("A valid connection string", ConnectionString::new),
         Importance.HIGH,

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -475,7 +475,7 @@ public class MongoSourceConfig extends AbstractConfig {
     int orderInGroup = 0;
     configDef.define(
         CONNECTION_URI_CONFIG,
-        Type.STRING,
+        Type.PASSWORD,
         CONNECTION_URI_DEFAULT,
         errorCheckingValueValidator("A valid connection string", ConnectionString::new),
         Importance.HIGH,


### PR DESCRIPTION
Since the `connection.uri` config has user credentials, it needs to be of type `PASSWORD` so it's values are correct redacted in logs