### PR TITLE
Set null WriteModel for tombstone record when delete.on.null is false.

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyHelper.java
@@ -56,7 +56,7 @@ public final class WriteModelStrategyHelper {
       return config
           .getDeleteOneWriteModelStrategy()
           .map(s -> s.createWriteModel(sinkDocument))
-          .orElseThrow(() -> new DataException("Could not create write model"));
+          .orElse(null);
     } catch (Exception e) {
       throw new DataException("Could not create write model", e);
     }

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordDataTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordDataTest.java
@@ -71,6 +71,10 @@ class MongoProcessedSinkRecordDataTest {
       new SinkRecord(
           TEST_TOPIC, 0, Schema.STRING_SCHEMA, "{_id: 1}", Schema.STRING_SCHEMA, VALUE_JSON, 1);
 
+  private static final SinkRecord TOMBSTONE_SINK_RECORD =
+      new SinkRecord(
+          TEST_TOPIC, 0, Schema.STRING_SCHEMA, "{_id: 1}", null, null, 1);
+
   private static final SinkRecord INVALID_SINK_RECORD =
       new SinkRecord(TEST_TOPIC, 0, Schema.INT32_SCHEMA, 1, Schema.INT32_SCHEMA, 1, 1);
 
@@ -105,6 +109,16 @@ class MongoProcessedSinkRecordDataTest {
 
     assertEquals(new MongoNamespace("myDB.myColl"), processedData.getNamespace());
     assertWriteModel(processedData);
+  }
+
+  @Test
+  @DisplayName("test default processing tombstone record")
+  void testDefaultProcessingTombstone() {
+    MongoProcessedSinkRecordData processedData =
+        new MongoProcessedSinkRecordData(TOMBSTONE_SINK_RECORD, createSinkConfig());
+
+    assertEquals(new MongoNamespace("myDB.topic"), processedData.getNamespace());
+    assertNull(processedData.getWriteModel());
   }
 
   @Test


### PR DESCRIPTION
The following commit changed the behavior with a few default configurations. Previously with `BsonOidStrategy`, `ReplaceOneDefaultStrategy,` and `delete.on.null` false, the connector did not fail. Now it does. 
https://github.com/mongodb/mongo-kafka/commit/ec659d1b286de4ed9adbd525763d926222852943#diff-c37d53a9743c28875d760f84ae0d038219d45abf85db9626dd93ecd39711e53cR59

This PR tries to bring the old behavior back.