### PR TITLE
Getting locales from their string representations

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/util/FlexibleDateTimeParser.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/FlexibleDateTimeParser.java
@@ -47,7 +47,7 @@ public class FlexibleDateTimeParser {
   private final DateTimeFormatter formatter;
 
   public FlexibleDateTimeParser(final String dateTimePattern, final String languageTag) {
-    Locale locale = languageTag.isEmpty() ? Locale.ROOT : Locale.forLanguageTag(languageTag);
+    Locale locale = languageTag.isEmpty() ? Locale.ROOT : getLocaleFromString(languageTag);
     this.formatter = DateTimeFormatter.ofPattern(dateTimePattern, locale);
   }
 
@@ -61,5 +61,28 @@ public class FlexibleDateTimeParser {
       return LocalDate.from(parsed).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
     }
     throw new DateTimeParseException("Unsupported date time string", dateTimeString, 0);
+  }
+
+  public static Locale getLocaleFromString(String localeTag) {
+    if (!localeTag.contains("_")) {
+      // IETF BCP 14 tag
+      return Locale.forLanguageTag(localeTag);
+    }
+
+    int languageIndex = localeTag.indexOf('_');
+    String language = localeTag.substring(0, languageIndex);
+
+    int countryIndex = localeTag.indexOf('_', languageIndex + 1);
+    String country = null;
+    if (countryIndex == -1) {
+      // no more '_'. So we have lang_COUNTRY.
+      country = localeTag.substring(languageIndex + 1);
+      return new Locale(language, country);
+    } else {
+      // More '_'. So we have lang_COUNTRY_variant
+      country = localeTag.substring(languageIndex + 1, countryIndex);
+      String variant = localeTag.substring(countryIndex + 1);
+      return new Locale(language, country, variant);
+    }
   }
 }

--- a/src/test/java/com/mongodb/kafka/connect/util/FlexibleDateTimeParserTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/util/FlexibleDateTimeParserTest.java
@@ -16,11 +16,15 @@
 package com.mongodb.kafka.connect.util;
 
 import static com.mongodb.kafka.connect.util.FlexibleDateTimeParser.DEFAULT_DATE_TIME_FORMATTER_PATTERN;
+import static com.mongodb.kafka.connect.util.FlexibleDateTimeParser.getLocaleFromString;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.text.DateFormat;
 import java.time.format.DateTimeParseException;
+import java.util.Arrays;
+import java.util.Locale;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -120,5 +124,18 @@ public class FlexibleDateTimeParserTest {
         3600000,
         new FlexibleDateTimeParser("EEEE, MMM dd, yyyy HH:mm:ss", "en")
             .toEpochMilli("Thursday, Jan 01, 1970 01:00:00"));
+  }
+
+  @Test
+  @DisplayName("String to locale mappings")
+  void testStringToLocaleMappings() {
+    Locale[] localArr = DateFormat.getAvailableLocales();
+    Locale[] genArr =
+        Arrays.stream(localArr).map(l -> getLocaleFromString(l.toString())).toArray(Locale[]::new);
+    for (int i = 0; i < localArr.length; i++) {
+      assertEquals(localArr[i].toString(), genArr[i].toString());
+      assertEquals(localArr[i].getCountry(), genArr[i].getCountry());
+      assertEquals(localArr[i].getLanguage(), genArr[i].getLanguage());
+    }
   }
 }


### PR DESCRIPTION
The MongoDb connector config `timeseries.timefield.auto.convert.locale.language.tag` expects the locale tag in the IETF BCP 47 format containing hyphens (-). But the recommender that we use for locales on CCloud recommends the locales in their exact string form (i.e. with underscores).
For example: mongo expects en-US but recommender provides en_US.

The Locale.forLanguageTag(languageTag) expects the languageTag to be in BCP 47 format and will not work with recommended locale string.
This PR aims to construct locales from their string representation to allow the conversion.