### PR TITLE
Throw ConnectException if resume of change stream is not possible

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -67,6 +67,7 @@ import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoException;
+import com.mongodb.MongoQueryException;
 import com.mongodb.client.ChangeStreamIterable;
 import com.mongodb.client.MongoChangeStreamCursor;
 import com.mongodb.client.MongoClient;
@@ -632,10 +633,10 @@ public final class MongoSourceTask extends SourceTask {
           if (sourceConfig.tolerateErrors() && changeStreamNotValid(e)) {
             cursor = tryRecreateCursor(e);
           } else {
-            LOGGER.info(
+            LOGGER.error(
                 "An exception occurred when trying to get the next item from the Change Stream", e);
-            if (e instanceof MongoCommandException &&
-                ((MongoCommandException) e).getErrorCode() == 286) {
+            if (e instanceof MongoQueryException &&
+                ((MongoQueryException) e).getErrorCode() == 286) {
               throw new ConnectException("Failed to resume change stream", e);
             }
           }

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -634,6 +634,10 @@ public final class MongoSourceTask extends SourceTask {
           } else {
             LOGGER.info(
                 "An exception occurred when trying to get the next item from the Change Stream", e);
+            if (e instanceof MongoCommandException &&
+                ((MongoCommandException) e).getErrorCode() == 286) {
+              throw new ConnectException("Failed to resume change stream", e);
+            }
           }
         }
         return Optional.empty();


### PR DESCRIPTION
Issue:
Connector is seeing the exception `com.mongodb.MongoQueryException: Query failed with error code 286 and error message 'Error on remote shard SOMENAME.mongodb.net:27017 :: caused by :: Resume of change stream was not possible, as the resume point may no longer be in the oplog.'` within the mongo client code but not surfacing it up; causing the connector to run indefinitely without producing any new records.

Mitigating action:
Throwing the ConnectException as it says that resume of change stream itself is not possible.
The connector should fail if this happens again.