### PR TITLE
Handle invalid host in url throwing exception.

### DIFF
--- a/src/integrationTest/java/com/mongodb/kafka/connect/ConnectorValidationIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/ConnectorValidationIntegrationTest.java
@@ -400,6 +400,12 @@ public final class ConnectorValidationIntegrationTest {
   }
 
   @Test
+  @DisplayName("Ensure source configuration validation handles invalid connection host in Url")
+  void testSourceConfigValidationInvalidConnectionUrl() {
+    assertInvalidSource(createSourceProperties("mongodb+srv://mongo:mongo@27017"));
+  }
+
+  @Test
   @DisplayName("Ensure source configuration validation works with invalid serverApi")
   void testSourceConfigValidationWithInvalidServerApi() {
     assumeFalse(isAtleastFiveDotZero(getMongoClient()));

--- a/src/main/java/com/mongodb/kafka/connect/util/ConnectionValidator.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/ConnectionValidator.java
@@ -74,34 +74,41 @@ public final class ConnectionValidator {
       MongoClientSettings.Builder mongoClientSettingsBuilder =
           MongoClientSettings.builder().applyConnectionString(connectionString);
       setServerApi(mongoClientSettingsBuilder, config);
+      final MongoClientSettings mongoClientSettings;
+      try {
+        mongoClientSettings =
+            mongoClientSettingsBuilder
+                .applyToClusterSettings(
+                    b ->
+                        b.addClusterListener(
+                            new ClusterListener() {
+                              @Override
+                              public void clusterOpening(final ClusterOpeningEvent event) {}
 
-      MongoClientSettings mongoClientSettings =
-          mongoClientSettingsBuilder
-              .applyToClusterSettings(
-                  b ->
-                      b.addClusterListener(
-                          new ClusterListener() {
-                            @Override
-                            public void clusterOpening(final ClusterOpeningEvent event) {}
+                              @Override
+                              public void clusterClosed(final ClusterClosedEvent event) {}
 
-                            @Override
-                            public void clusterClosed(final ClusterClosedEvent event) {}
-
-                            @Override // Different database than has permissions for
-                            public void clusterDescriptionChanged(
-                                final ClusterDescriptionChangedEvent event) {
-                              ReadPreference readPreference =
-                                  connectionString.getReadPreference() != null
-                                      ? connectionString.getReadPreference()
-                                      : ReadPreference.primaryPreferred();
-                              if (!connected.get()
-                                  && event.getNewDescription().hasReadableServer(readPreference)) {
-                                connected.set(true);
-                                latch.countDown();
+                              @Override // Different database than has permissions for
+                              public void clusterDescriptionChanged(
+                                  final ClusterDescriptionChangedEvent event) {
+                                ReadPreference readPreference =
+                                    connectionString.getReadPreference() != null
+                                        ? connectionString.getReadPreference()
+                                        : ReadPreference.primaryPreferred();
+                                if (!connected.get()
+                                    && event
+                                        .getNewDescription()
+                                        .hasReadableServer(readPreference)) {
+                                  connected.set(true);
+                                  latch.countDown();
+                                }
                               }
-                            }
-                          }))
-              .build();
+                            }))
+                .build();
+      } catch (IllegalArgumentException exception) {
+        configValue.addErrorMessage(exception.getMessage());
+        return Optional.empty();
+      }
 
       long latchTimeout =
           mongoClientSettings.getSocketSettings().getConnectTimeout(TimeUnit.MILLISECONDS) + 500;


### PR DESCRIPTION
Fix for: https://confluentinc.atlassian.net/browse/CCDB-5028

When connection.host provided by user does not contain three parts (delimited by '.'), illegalArgumentException is thrown which is not caught and /validate call fails.

As a solution, the exception is caught in validate and the error is returned in Config.
