### PR TITLE
Cherrypick local changes from previous releases (#32)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# See go/codeowners - automatically generated for confluentinc/mongo-kafka:
+*	@confluentinc/connect
+*	@confluentinc/connect-cloud

--- a/src/integrationTest/java/com/mongodb/kafka/connect/ConnectorValidationIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/ConnectorValidationIntegrationTest.java
@@ -400,6 +400,12 @@ public final class ConnectorValidationIntegrationTest {
   }
 
   @Test
+  @DisplayName("Ensure source configuration validation handles invalid connection host in Url")
+  void testSourceConfigValidationInvalidConnectionUrl() {
+    assertInvalidSource(createSourceProperties("mongodb+srv://mongo:mongo@27017"));
+  }
+
+  @Test
   @DisplayName("Ensure source configuration validation works with invalid serverApi")
   void testSourceConfigValidationWithInvalidServerApi() {
     assumeFalse(isAtleastFiveDotZero(getMongoClient()));

--- a/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
@@ -797,8 +797,7 @@ public class MongoSourceTaskIntegrationTest extends MongoKafkaTestCase {
           task.logCapture.getEvents().stream()
               .filter(e -> e.getLevel().equals(Level.ERROR))
               .anyMatch(
-                  e ->
-                      e.getMessage().toString().contains("Exception creating Source record for:")));
+                  e -> e.getMessage().toString().contains("Exception creating Source record")));
 
       // Reset and test copy existing without logs
       task.stop();
@@ -816,7 +815,7 @@ public class MongoSourceTaskIntegrationTest extends MongoKafkaTestCase {
               .findFirst()
               .map(e -> e.getMessage().toString())
               .orElseGet(() -> "")
-              .contains("Exception creating Source record for:"));
+              .contains("Exception creating Source record"));
       task.stop();
     }
   }
@@ -850,7 +849,7 @@ public class MongoSourceTaskIntegrationTest extends MongoKafkaTestCase {
       insertMany(rangeClosed(4, 5), coll);
 
       Exception e = assertThrows(DataException.class, () -> getNextResults(task));
-      assertTrue(e.getMessage().contains("Exception creating Source record for:"));
+      assertTrue(e.getMessage().contains("Exception creating Source record"));
     }
   }
 

--- a/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest2.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest2.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.connect.source.SourceTaskContext;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
+import org.junit.Ignore;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordData.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordData.java
@@ -106,7 +106,12 @@ final class MongoProcessedSinkRecordData {
     } catch (Exception e) {
       exception = e;
       if (config.logErrors()) {
-        LOGGER.error("Unable to process record {}", sinkRecord, e);
+        LOGGER.error(
+            "Unable to process record in topic:{} at partition:{}, offset:{}",
+            sinkRecord.topic(),
+            sinkRecord.kafkaPartition(),
+            sinkRecord.kafkaOffset(),
+            e);
       }
       if (!config.tolerateErrors()) {
         throw e;

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/ChangeStreamHandler.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/ChangeStreamHandler.java
@@ -64,10 +64,7 @@ public final class ChangeStreamHandler extends CdcHandler {
     BsonDocument changeStreamDocument = doc.getValueDoc().orElseGet(BsonDocument::new);
 
     if (!changeStreamDocument.containsKey(OPERATION_TYPE)) {
-      throw new DataException(
-          format(
-              "Error: `%s` field is doc is missing. %s",
-              OPERATION_TYPE, changeStreamDocument.toJson()));
+      throw new DataException(format("Error: `%s` field in doc is missing", OPERATION_TYPE));
     } else if (!changeStreamDocument.get(OPERATION_TYPE).isString()) {
       throw new DataException("Error: Unexpected CDC operation type, should be a string");
     }
@@ -76,9 +73,6 @@ public final class ChangeStreamHandler extends CdcHandler {
         OperationType.fromString(changeStreamDocument.get(OPERATION_TYPE).asString().getValue());
 
     LOGGER.debug("Creating operation handler for: {}", operationType);
-    if (LOGGER.isTraceEnabled()) {
-      LOGGER.trace("ChangeStream document {}", changeStreamDocument.toJson());
-    }
 
     if (OPERATIONS.containsKey(operationType)) {
       return Optional.of(OPERATIONS.get(operationType).perform(doc));

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/OperationHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/OperationHelper.java
@@ -46,13 +46,12 @@ final class OperationHelper {
 
   static BsonDocument getDocumentKey(final BsonDocument changeStreamDocument) {
     if (!changeStreamDocument.containsKey(DOCUMENT_KEY)) {
-      throw new DataException(
-          format("Missing %s field: %s", DOCUMENT_KEY, changeStreamDocument.toJson()));
+      throw new DataException(format("Missing %s field", DOCUMENT_KEY));
     } else if (!changeStreamDocument.get(DOCUMENT_KEY).isDocument()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expecting a document but found `%s`: %s",
-              DOCUMENT_KEY, changeStreamDocument.get(DOCUMENT_KEY), changeStreamDocument.toJson()));
+              "Unexpected %s field type, expecting a document but found `%s`",
+              DOCUMENT_KEY, changeStreamDocument.get(DOCUMENT_KEY)));
     }
 
     return changeStreamDocument.getDocument(DOCUMENT_KEY);
@@ -64,15 +63,12 @@ final class OperationHelper {
 
   static BsonDocument getFullDocument(final BsonDocument changeStreamDocument) {
     if (!changeStreamDocument.containsKey(FULL_DOCUMENT)) {
-      throw new DataException(
-          format("Missing %s field: %s", FULL_DOCUMENT, changeStreamDocument.toJson()));
+      throw new DataException(format("Missing %s field", FULL_DOCUMENT));
     } else if (!changeStreamDocument.get(FULL_DOCUMENT).isDocument()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expecting a document but found `%s`: %s",
-              FULL_DOCUMENT,
-              changeStreamDocument.get(FULL_DOCUMENT),
-              changeStreamDocument.toJson()));
+              "Unexpected %s field type, expecting a document but found `%s`",
+              FULL_DOCUMENT, changeStreamDocument.get(FULL_DOCUMENT)));
     }
 
     return changeStreamDocument.getDocument(FULL_DOCUMENT);
@@ -80,15 +76,12 @@ final class OperationHelper {
 
   static BsonDocument getUpdateDocument(final BsonDocument changeStreamDocument) {
     if (!changeStreamDocument.containsKey(UPDATE_DESCRIPTION)) {
-      throw new DataException(
-          format("Missing %s field: %s", UPDATE_DESCRIPTION, changeStreamDocument.toJson()));
+      throw new DataException(format("Missing %s field", UPDATE_DESCRIPTION));
     } else if (!changeStreamDocument.get(UPDATE_DESCRIPTION).isDocument()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expected a document found `%s`: %s",
-              UPDATE_DESCRIPTION,
-              changeStreamDocument.get(UPDATE_DESCRIPTION),
-              changeStreamDocument.toJson()));
+              "Unexpected %s field type, expected a document found `%s`",
+              UPDATE_DESCRIPTION, changeStreamDocument.get(UPDATE_DESCRIPTION)));
     }
 
     BsonDocument updateDescription = changeStreamDocument.getDocument(UPDATE_DESCRIPTION);
@@ -97,32 +90,26 @@ final class OperationHelper {
     if (!updateDescriptionFields.isEmpty()) {
       throw new DataException(
           format(
-              "Warning unexpected field(s) in %s %s. %s. Cannot process due to risk of data loss.",
-              UPDATE_DESCRIPTION, updateDescriptionFields, updateDescription.toJson()));
+              "Warning unexpected field(s) in %s %s. Cannot process due to risk of data loss.",
+              UPDATE_DESCRIPTION, updateDescriptionFields));
     }
 
     if (!updateDescription.containsKey(UPDATED_FIELDS)) {
-      throw new DataException(
-          format(
-              "Missing %s.%s field: %s",
-              UPDATE_DESCRIPTION, UPDATED_FIELDS, updateDescription.toJson()));
+      throw new DataException(format("Missing %s.%s field", UPDATE_DESCRIPTION, UPDATED_FIELDS));
     } else if (!updateDescription.get(UPDATED_FIELDS).isDocument()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expected a document but found `%s`: %s",
-              UPDATE_DESCRIPTION, updateDescription, updateDescription.toJson()));
+              "Unexpected %s field type, expected a document but found `%s`",
+              UPDATE_DESCRIPTION, updateDescription));
     }
 
     if (!updateDescription.containsKey(REMOVED_FIELDS)) {
-      throw new DataException(
-          format(
-              "Missing %s.%s field: %s",
-              UPDATE_DESCRIPTION, REMOVED_FIELDS, updateDescription.toJson()));
+      throw new DataException(format("Missing %s.%s field", UPDATE_DESCRIPTION, REMOVED_FIELDS));
     } else if (!updateDescription.get(REMOVED_FIELDS).isArray()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expected an array but found `%s`: %s",
-              REMOVED_FIELDS, updateDescription.get(REMOVED_FIELDS), updateDescription.toJson()));
+              "Unexpected %s field type, expected an array but found `%s`",
+              REMOVED_FIELDS, updateDescription.get(REMOVED_FIELDS)));
     }
 
     BsonDocument updatedFields = updateDescription.getDocument(UPDATED_FIELDS);
@@ -132,8 +119,8 @@ final class OperationHelper {
       if (!removedField.isString()) {
         throw new DataException(
             format(
-                "Unexpected value type in %s, expected an string but found `%s`: %s",
-                REMOVED_FIELDS, removedField, updateDescription.toJson()));
+                "Unexpected value type in %s, expected an string but found `%s`",
+                REMOVED_FIELDS, removedField));
       }
       unsetDocument.append(removedField.asString().getValue(), EMPTY_STRING);
     }

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/qlik/rdbms/RdbmsHandler.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/qlik/rdbms/RdbmsHandler.java
@@ -17,7 +17,6 @@
 package com.mongodb.kafka.connect.sink.cdc.qlik.rdbms;
 
 import static com.mongodb.kafka.connect.sink.cdc.qlik.rdbms.operations.OperationHelper.DEFAULT_OPERATIONS;
-import static java.lang.String.format;
 
 import java.util.Map;
 import java.util.Optional;
@@ -71,12 +70,7 @@ public class RdbmsHandler extends QlikCdcHandler {
     OperationType operationType = OperationHelper.getOperationType(valueDocument);
     CdcOperation cdcOperation =
         getCdcOperation(operationType)
-            .orElseThrow(
-                () ->
-                    new DataException(
-                        format(
-                            "Unable to determine the CDC operation from: %s",
-                            valueDocument.toJson())));
+            .orElseThrow(() -> new DataException("Unable to determine the CDC operation"));
 
     return Optional.ofNullable(cdcOperation.perform(new SinkDocument(keyDocument, valueDocument)));
   }

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/qlik/rdbms/operations/OperationHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/qlik/rdbms/operations/OperationHelper.java
@@ -83,8 +83,7 @@ public final class OperationHelper {
     }
 
     if (!operation.isString()) {
-      throw new DataException(
-          format("Error: Could not determine the CDC operation type. %s", valueDocument.toJson()));
+      throw new DataException("Error: Could not determine the CDC operation type.");
     }
 
     return OperationType.fromString(operation.asString().getValue());
@@ -107,9 +106,7 @@ public final class OperationHelper {
                 });
     if (filter.isEmpty()) {
       throw new DataException(
-          format(
-              "Error: Value Document does not contain the expected data, cannot create filter: %s.",
-              valueDocument.toJson()));
+          "Error: Value Document does not contain the expected data, cannot create filter.");
     }
     return filter;
   }
@@ -128,9 +125,7 @@ public final class OperationHelper {
                 });
     if (filter.isEmpty()) {
       throw new DataException(
-          format(
-              "Error: Value Document does not contain the expected data, cannot create filter: %s.",
-              valueDocument.toJson()));
+          "Error: Value Document does not contain the expected data, cannot create filter.");
     }
     return filter;
   }
@@ -157,9 +152,7 @@ public final class OperationHelper {
 
     if (afterDocument.isEmpty()) {
       throw new DataException(
-          format(
-              "Error: Value Document does not contain the expected data, cannot create filter: %s.",
-              valueDocument.toJson()));
+          "Error: Value Document does not contain the expected data, cannot create filter.");
     }
 
     BsonDocument updates = new BsonDocument();
@@ -205,9 +198,7 @@ public final class OperationHelper {
 
       if (!fieldValue.isDocument()) {
         throw new DataException(
-            format(
-                "Error: Value document contains a '%s' that is not a document: %s",
-                fieldName, original));
+            format("Error: Value document contains a '%s' that is not a document", fieldName));
       }
       return fieldValue.asDocument();
     }

--- a/src/main/java/com/mongodb/kafka/connect/sink/converter/LazyBsonDocument.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/converter/LazyBsonDocument.java
@@ -161,8 +161,9 @@ public class LazyBsonDocument extends BsonDocument {
           } catch (Exception e) {
             throw new DataException(
                 format(
-                    "Could not convert key %s into a BsonDocument.",
-                    unambiguousToString(record.key())),
+                    "Could not convert key in topic:%s at partition:%s offset:%s into a "
+                        + "BsonDocument",
+                    record.topic(), record.kafkaPartition(), record.kafkaOffset()),
                 e);
           }
           break;
@@ -172,8 +173,9 @@ public class LazyBsonDocument extends BsonDocument {
           } catch (Exception e) {
             throw new DataException(
                 format(
-                    "Could not convert value %s into a BsonDocument.",
-                    unambiguousToString(record.value())),
+                    "Could not convert value in topic:%s at partition:%s offset:%s into a "
+                        + "BsonDocument.",
+                    record.topic(), record.kafkaPartition(), record.kafkaOffset()),
                 e);
           }
           break;

--- a/src/main/java/com/mongodb/kafka/connect/sink/converter/SinkConverter.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/converter/SinkConverter.java
@@ -39,7 +39,11 @@ public class SinkConverter {
   private static final RecordConverter BYTE_ARRAY_RECORD_CONVERTER = new ByteArrayRecordConverter();
 
   public SinkDocument convert(final SinkRecord record) {
-    LOGGER.debug("record: {}", record);
+    LOGGER.debug(
+        "record in topic:{} at partition:{}, offset:{}",
+        record.topic(),
+        record.kafkaPartition(),
+        record.kafkaOffset());
 
     BsonDocument keyDoc = null;
     if (record.key() != null) {

--- a/src/main/java/com/mongodb/kafka/connect/sink/namespace/mapping/FieldPathNamespaceMapper.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/namespace/mapping/FieldPathNamespaceMapper.java
@@ -133,22 +133,25 @@ public class FieldPathNamespaceMapper implements NamespaceMapper {
           optionalData.orElseThrow(
               () ->
                   new DataException(
-                      format("Invalid %s document: %s", isKey ? "key" : "value", sinkRecord)));
+                      format(
+                          "Invalid %s document in topic:%s at partition:%s offset:%s",
+                          isKey ? "key" : "value",
+                          sinkRecord.topic(),
+                          sinkRecord.kafkaPartition(),
+                          sinkRecord.kafkaOffset())));
 
       Optional<BsonValue> optionalFieldValue = fieldLookup(path, data);
       if (continueProcessing(optionalFieldValue.isPresent())) {
         BsonValue fieldValue =
             optionalFieldValue.orElseThrow(
-                () ->
-                    new DataException(
-                        format("Missing document path '%s': %s", path, data.toJson())));
+                () -> new DataException(format("Missing document path '%s'", path)));
 
         if (continueProcessing(fieldValue.isString())) {
           if (!fieldValue.isString()) {
             throw new DataException(
                 format(
-                    "Invalid type for %s field path '%s', expected a String: %s",
-                    fieldValue.getBsonType(), path, data.toJson()));
+                    "Invalid type for %s field path '%s', expected a String",
+                    fieldValue.getBsonType(), path));
           }
 
           return fieldValue.asString().getValue();

--- a/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyHelper.java
@@ -56,7 +56,7 @@ public final class WriteModelStrategyHelper {
       return config
           .getDeleteWriteModelStrategy()
           .map(s -> s.createWriteModel(sinkDocument))
-          .orElseThrow(() -> new DataException("Could not create write model"));
+          .orElse(null);
     } catch (Exception e) {
       throw new DataException("Could not create write model", e);
     }

--- a/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
@@ -75,6 +75,7 @@ import org.bson.RawBsonDocument;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoException;
+import com.mongodb.MongoQueryException;
 import com.mongodb.client.ChangeStreamIterable;
 import com.mongodb.client.MongoChangeStreamCursor;
 import com.mongodb.client.MongoClient;
@@ -221,9 +222,7 @@ final class StartedMongoSourceTask implements AutoCloseable {
 
               String topicName = topicMapper.getTopic(changeStreamDocument);
               if (topicName.isEmpty()) {
-                LOGGER.warn(
-                    "No topic set. Could not publish the message: {}",
-                    changeStreamDocument.toJson());
+                LOGGER.warn("No topic set. Could not publish the message.");
               } else {
 
                 Optional<BsonDocument> valueDocument = Optional.empty();
@@ -309,13 +308,7 @@ final class StartedMongoSourceTask implements AutoCloseable {
               valueSchemaAndValue.schema(),
               valueSchemaAndValue.value()));
     } catch (Exception e) {
-      Supplier<String> errorMessage =
-          () ->
-              format(
-                  "%s : Exception creating Source record for: Key=%s Value=%s",
-                  e.getMessage(),
-                  keyDocument == null ? "" : keyDocument.toJson(),
-                  valueDocument == null ? "" : valueDocument.toJson());
+      Supplier<String> errorMessage = () -> "Exception creating Source record";
       if (sourceConfig.logErrors()) {
         LOGGER.error(errorMessage.get(), e);
       }
@@ -483,6 +476,8 @@ final class StartedMongoSourceTask implements AutoCloseable {
         if (changeStreamNotValid(e)) {
           throw new ConnectException(
               "ResumeToken not found. Cannot create a change stream cursor", e);
+        } else {
+          throw new ConnectException("Failed to resume change stream", e);
         }
       }
       return null;
@@ -602,8 +597,11 @@ final class StartedMongoSourceTask implements AutoCloseable {
         if (sourceConfig.tolerateErrors() && changeStreamNotValid(e)) {
           cursor = tryRecreateCursor(e);
         } else {
-          LOGGER.info(
+          LOGGER.error(
               "An exception occurred when trying to get the next item from the Change Stream", e);
+          if (e instanceof MongoQueryException && ((MongoQueryException) e).getErrorCode() == 286) {
+            throw new ConnectException("Failed to resume change stream", e);
+          }
         }
       }
     } catch (Exception e) {

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValue.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValue.java
@@ -310,7 +310,6 @@ public class BsonValueToSchemaAndValue {
   }
 
   private DataException missingFieldException(final Field field, final BsonDocument value) {
-    return new DataException(
-        format("Missing field '%s' in: '%s'", field.name(), value.toJson(jsonWriterSettings)));
+    return new DataException(format("Missing field '%s'", field.name()));
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/util/Validators.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/Validators.java
@@ -40,6 +40,8 @@ import com.mongodb.kafka.connect.util.config.BsonTimestampParser;
 
 public final class Validators {
 
+  private static String redactedUrl = "[REDACTED URL]";
+
   public interface ValidatorWithOperators extends ConfigDef.Validator {
     default ValidatorWithOperators or(final ValidatorWithOperators other) {
       return withStringDef(
@@ -162,7 +164,7 @@ public final class Validators {
           try {
             consumer.accept((String) value);
           } catch (Exception e) {
-            throw new ConfigException(name, value, e.getMessage());
+            throw new ConfigException(name, redactedUrl, e.getMessage());
           }
         }));
   }

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordDataTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordDataTest.java
@@ -70,6 +70,9 @@ class MongoProcessedSinkRecordDataTest {
       new SinkRecord(
           TEST_TOPIC, 0, Schema.STRING_SCHEMA, "{_id: 1}", Schema.STRING_SCHEMA, VALUE_JSON, 1);
 
+  private static final SinkRecord TOMBSTONE_SINK_RECORD =
+      new SinkRecord(TEST_TOPIC, 0, Schema.STRING_SCHEMA, "{_id: 1}", null, null, 1);
+
   private static final SinkRecord INVALID_SINK_RECORD =
       new SinkRecord(TEST_TOPIC, 0, Schema.INT32_SCHEMA, 1, Schema.INT32_SCHEMA, 1, 1);
 
@@ -104,6 +107,16 @@ class MongoProcessedSinkRecordDataTest {
 
     assertEquals(new MongoNamespace("myDB.myColl"), processedData.getNamespace());
     assertWriteModel(processedData);
+  }
+
+  @Test
+  @DisplayName("test default processing tombstone record")
+  void testDefaultProcessingTombstone() {
+    MongoProcessedSinkRecordData processedData =
+        new MongoProcessedSinkRecordData(TOMBSTONE_SINK_RECORD, createSinkConfig());
+
+    assertEquals(new MongoNamespace("myDB.topic"), processedData.getNamespace());
+    assertNull(processedData.getWriteModel());
   }
 
   @Test


### PR DESCRIPTION
* resolved merge conflicts

* Throw ConnectException if resume of change stream is not possible

* indentation and formatting

Ref: https://github.com/confluentinc/mongo-kafka/pull/32