### PR TITLE
Update build version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ plugins {
 }
 
 group = "org.mongodb.kafka"
-version = "1.10.1-rc-5c10f72"
+version = "1.10.1-rc-9be9f25"
 description = "The official MongoDB Apache Kafka Connect Connector."
 
 repositories {


### PR DESCRIPTION
Updating to `1.10.1-rc-9be9f25` for releasing new version with RCCA-17134 fix.
Following https://github.com/confluentinc/mongo-kafka/tree/v1.10.x?tab=readme-ov-file#releasing-ccloud-connectors-to-confluent-staging-bucket 