### PR TITLE
CC-27090: Add upsert replace option for ReplaceOneModel in update operation

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/Update.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/Update.java
@@ -31,6 +31,7 @@ import org.bson.BsonDocument;
 
 import com.mongodb.client.model.ReplaceOneModel;
 import com.mongodb.client.model.UpdateOneModel;
+import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.WriteModel;
 
 import com.mongodb.kafka.connect.sink.cdc.CdcOperation;
@@ -50,7 +51,9 @@ public class Update implements CdcOperation {
     BsonDocument documentKey = getDocumentKey(changeStreamDocument);
     if (hasFullDocument(changeStreamDocument)) {
       LOGGER.debug("The full Document available, creating a replace operation.");
-      return new ReplaceOneModel<>(documentKey, getFullDocument(changeStreamDocument));
+      return new ReplaceOneModel<>(documentKey,
+              getFullDocument(changeStreamDocument),
+              new ReplaceOptions().upsert(true));
     }
 
     LOGGER.debug("No full document field available, creating update operation.");

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/Update.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/Update.java
@@ -30,8 +30,8 @@ import org.slf4j.LoggerFactory;
 import org.bson.BsonDocument;
 
 import com.mongodb.client.model.ReplaceOneModel;
-import com.mongodb.client.model.UpdateOneModel;
 import com.mongodb.client.model.ReplaceOptions;
+import com.mongodb.client.model.UpdateOneModel;
 import com.mongodb.client.model.WriteModel;
 
 import com.mongodb.kafka.connect.sink.cdc.CdcOperation;
@@ -51,9 +51,8 @@ public class Update implements CdcOperation {
     BsonDocument documentKey = getDocumentKey(changeStreamDocument);
     if (hasFullDocument(changeStreamDocument)) {
       LOGGER.debug("The full Document available, creating a replace operation.");
-      return new ReplaceOneModel<>(documentKey,
-              getFullDocument(changeStreamDocument),
-              new ReplaceOptions().upsert(true));
+      return new ReplaceOneModel<>(
+          documentKey, getFullDocument(changeStreamDocument), new ReplaceOptions().upsert(true));
     }
 
     LOGGER.debug("No full document field available, creating update operation.");

--- a/src/test/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/UpdateTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/UpdateTest.java
@@ -74,9 +74,9 @@ class UpdateTest {
         "filter expected to be of type BsonDocument");
     assertEquals(CHANGE_EVENT.getDocument("documentKey"), writeModel.getFilter());
     assertEquals(CHANGE_EVENT.getDocument("fullDocument"), writeModel.getReplacement());
-    assertFalse(
+    assertTrue(
         writeModel.getReplaceOptions().isUpsert(),
-        "update replacement expected not to be in upsert mode");
+        "update replacement expected to be in upsert mode");
   }
 
   @Test


### PR DESCRIPTION
For cdc handler `MongoDbChangeStreamHandler`, the connector does not perform upsert for an update operation - https://github.com/confluentinc/mongo-kafka/blob/1e43511950bb156f75c5bee07bebe980e03bbd44/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/Update.java#L53

Adding upsert = true to perform always upsert for ReplaceOneModel. 

https://confluentinc.atlassian.net/browse/RCCA-19491 