### PR TITLE
Add semaphore file for v1.11.x

### DIFF
--- a/.semaphore/project.yml
+++ b/.semaphore/project.yml
@@ -1,0 +1,43 @@
+# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
+# template and configurations in service.yml.
+# Modifications in this file will be overwritten by generated content in the nightly run.
+# For more information, please refer to the page:
+# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
+apiVersion: v1alpha
+kind: Project
+metadata:
+  name: mongo-kafka
+  description: ""
+spec:
+  visibility: private
+  repository:
+    url: git@github.com:confluentinc/mongo-kafka.git
+    run_on:
+      - branches
+      - pull_requests
+    pipeline_file: .semaphore/semaphore.yml
+    integration_type: github_app
+    status:
+      pipeline_files:
+        - path: .semaphore/semaphore.yml
+          level: pipeline
+    whitelist:
+      branches:
+        - master
+        - main
+        - /^\d+\.\d+\.x$/
+        - /^gh-readonly-queue.*/
+  custom_permissions: true
+  debug_permissions:
+    - empty
+    - default_branch
+    - non_default_branch
+    - pull_request
+    - forked_pull_request
+    - tag
+  attach_permissions:
+    - default_branch
+    - non_default_branch
+    - pull_request
+    - forked_pull_request
+    - tag

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,65 @@
+# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
+# template and configurations in service.yml.
+# Any modifications made to ths file will be overwritten by the generated content in nightly runs.
+# For more information, please refer to the page:
+# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
+version: v1.0
+name: build-test-release
+agent:
+  machine:
+    type: s1-prod-ubuntu20-04-amd64-1
+
+fail_fast:
+  cancel:
+    when: "true"
+
+execution_time_limit:
+  hours: 1
+
+queue:
+  - when: "branch != 'master' and branch !~ 'v[0-9]+\\.[0-9]+\\.x'"
+    processing: parallel
+
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+      - sem-version java 8
+
+blocks:
+  - name: Test
+    dependencies: []
+    run:
+      # don't run the tests on non-functional changes...
+      when: "change_in('/', {exclude: ['/.deployed-versions/', '.github/']})"
+    task:
+      jobs:
+        - name: Test
+          commands:
+            - pip install confluent-release-tools -q
+            - . sem-pint
+            - ./gradlew test
+            - . cve-scan
+      epilogue:
+        always:
+          commands:
+            - . publish-test-results
+            - artifact push workflow target/test-results
+
+after_pipeline:
+  task:
+    agent:
+      machine:
+        type: s1-prod-ubuntu20-04-arm64-0
+    jobs:
+      - name: Metrics
+        commands:
+          - emit-ci-metrics -p -a test-results
+      - name: Publish Test Results
+        commands:
+          - test-results gen-pipeline-report
+      - name: SonarQube
+        commands:
+          - checkout
+          - sem-version java 11
+          - emit-sonarqube-data -a test-results

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -231,7 +231,7 @@ tasks.withType<com.github.spotbugs.snom.SpotBugsTask> {
 // Spotless is used to lint and reformat source files.
 spotless {
     java {
-        googleJavaFormat("1.12.0")
+        googleJavaFormat("1.7")
         importOrder("java", "io", "org", "org.bson", "com.mongodb", "com.mongodb.kafka", "")
         removeUnusedImports() // removes any unused imports
         trimTrailingWhitespace()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.java.installations.auto-download=false
 org.gradle.java.installations.fromEnv=JDK8,JDK17
-org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xmx1G --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xmx1G

--- a/service.yml
+++ b/service.yml
@@ -1,0 +1,13 @@
+name: mongo-kafka
+lang: java
+lang_version: 8
+git:
+  enable: true
+codeowners:
+  enable: true
+semaphore:
+  enable: true
+  pipeline_type: cp
+  cve_scan: true
+  extra_deploy_args: "-Dcloud -Pjenkins"
+  extra_build_args: "-Dcloud -Pjenkins"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+### service-bot sonarqube plugin managed file
+sonar.coverage.exclusions=**/test/**/*,**/tests/**/*,**/mock/**/*,**/mocks/**/*,**/*mock*,**/*test*
+sonar.coverage.jacoco.xmlReportPaths=**/jacoco.xml
+sonar.exclusions=**/*.pb.*,**/mk-include/**/*
+sonar.java.binaries=.
+sonar.language=java
+sonar.projectKey=mongo-kafka
+sonar.sources=.

--- a/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest2.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest2.java
@@ -39,7 +39,6 @@ import java.util.Map;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.connect.source.SourceTaskContext;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
-import org.junit.Ignore;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/main/java/com/mongodb/kafka/connect/util/ConnectionValidator.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/ConnectionValidator.java
@@ -120,7 +120,7 @@ public final class ConnectionValidator {
       MongoClient mongoClient = MongoClients.create(mongoClientSettings);
 
       try {
-        if (connectionString.isSrvProtocol()){
+        if (connectionString.isSrvProtocol()) {
           if (!latch.await(latchTimeout, TimeUnit.MILLISECONDS)) {
             configValue.addErrorMessage("Unable to connect to the server.");
             mongoClient.close();


### PR DESCRIPTION
Add semaphore file for v1.11.x
Similar to the master branch - https://github.com/confluentinc/mongo-kafka/pull/51
google-java-format version has been downgraded to fix compatibility issues with java version.
