### PR TITLE
[CC-32391] Use RegexUtils to avoid ReDOS in sink connector

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,7 @@ extra.apply {
     set("mongodbDriverVersion", "[4.7,4.7.99)")
     set("kafkaVersion", "2.6.0")
     set("avroVersion", "1.9.2")
+    set("connectUtilsVersion", "1.1.0")
 
     // Testing dependencies
     set("junitJupiterVersion", "5.8.1")
@@ -63,7 +64,6 @@ extra.apply {
     set("confluentVersion", "6.0.1")
     set("scalaVersion", "2.13")
     set("curatorVersion", "2.9.0")
-    set("connectUtilsVersion", "0.4+")
 }
 
 val mongoDependencies: Configuration by configurations.creating
@@ -73,6 +73,7 @@ dependencies {
     implementation("org.apache.kafka:connect-api:${project.extra["kafkaVersion"]}")
     implementation("org.mongodb:mongodb-driver-sync:${project.extra["mongodbDriverVersion"]}")
     implementation("org.apache.avro:avro:${project.extra["avroVersion"]}")
+    implementation("com.github.jcustenborder.kafka.connect:connect-utils:${project.extra["connectUtilsVersion"]}")
 
     mongoDependencies("org.mongodb:mongodb-driver-sync:${project.extra["mongodbDriverVersion"]}")
 

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
@@ -31,11 +31,14 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 import static org.apache.kafka.common.config.ConfigDef.Width;
+import com.github.jcustenborder.kafka.connect.utils.RegexUtils;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -70,6 +73,13 @@ public class MongoSinkConfig extends AbstractConfig {
           + " should be specified.";
   private static final String TOPICS_REGEX_DEFAULT = EMPTY_STRING;
   private static final String TOPICS_REGEX_DISPLAY = "Topics regex";
+
+  public static final String REGEX_TIMEOUT_MS = "regex.timeout.ms";
+  public static final long REGEX_TIMEOUT_MS_DEFAULT = 100;
+  public static final String REGEX_TIMEOUT_MS_DOC =
+          "Timeout in milliseconds for regex pattern operations.";
+  public static final String REGEX_TIMEOUT_MS_DISPLAY =
+          "Regex Timeout(ms)";
 
   public static final String CONNECTION_URI_CONFIG = "connection.uri";
   private static final String CONNECTION_URI_DEFAULT = "mongodb://localhost:27017";
@@ -134,15 +144,41 @@ public class MongoSinkConfig extends AbstractConfig {
     // Process and validate overrides of regex values.
     if (topicsRegex.isPresent()) {
       Pattern topicRegex = topicsRegex.get();
+      long regexTimeoutDuration = getLong(REGEX_TIMEOUT_MS);
       originals.keySet().stream()
           .filter(k -> k.startsWith(TOPIC_OVERRIDE_PREFIX))
           .forEach(
               k -> {
                 String topic = k.substring(TOPIC_OVERRIDE_PREFIX.length()).split("\\.")[0];
-                if (!topicSinkConnectorConfigMap.containsKey(topic)
-                    && topicRegex.matcher(topic).matches()) {
-                  topicSinkConnectorConfigMap.put(
-                      topic, new MongoSinkTopicConfig(topic, originals));
+                if (!topicSinkConnectorConfigMap.containsKey(topic)) {
+                    try {
+                        if (RegexUtils.matches(topicRegex, topic, regexTimeoutDuration)) {
+                            topicSinkConnectorConfigMap.put(
+                                topic, new MongoSinkTopicConfig(topic, originals));
+                        }
+                    } catch (TimeoutException e) {
+                      String message = format(
+                          "Regex match operation timed out after %dms. "
+                          + "A topic in the %s* configuration is causing the timeout. "
+                          + "Please check your configurations.",
+                          regexTimeoutDuration, TOPIC_OVERRIDE_PREFIX, TOPICS_REGEX_CONFIG, TOPIC_OVERRIDE_PREFIX);
+                      throw new ConfigException(message);
+                    } catch (InterruptedException e) {
+                      Thread.currentThread().interrupt();
+                      String message = format(
+                          "Thread was interrupted during topics.regex match: %s. "
+                          + "A topic in the %s* configuration is causing the timeout. "
+                          + "Please check your configurations.",
+                          e, regexTimeoutDuration, TOPIC_OVERRIDE_PREFIX, TOPICS_REGEX_CONFIG, TOPIC_OVERRIDE_PREFIX);
+                      throw new ConfigException(message);
+                    } catch (ExecutionException e) {
+                      String message = format(
+                          "Error during topics.regex match: %s. "
+                          + "A topic in the %s* configuration is causing the timeout. "
+                          + "Please check your configurations.",
+                          e, regexTimeoutDuration, TOPIC_OVERRIDE_PREFIX, TOPICS_REGEX_CONFIG, TOPIC_OVERRIDE_PREFIX);
+                      throw new ConfigException(message);
+                    }
                 }
               });
     }
@@ -171,6 +207,10 @@ public class MongoSinkConfig extends AbstractConfig {
 
   public Map<String, String> getOriginals() {
     return originals;
+  }
+
+  public long getRegexTimeoutMs() {
+    return getLong(REGEX_TIMEOUT_MS);
   }
 
   public MongoSinkTopicConfig getMongoSinkTopicConfig(final String topic) {
@@ -300,6 +340,7 @@ public class MongoSinkConfig extends AbstractConfig {
         TOPIC_OVERRIDE_DISPLAY);
 
     configDef.defineInternal(PROVIDER_CONFIG, Type.STRING, "", Importance.LOW);
+    configDef.defineInternal(REGEX_TIMEOUT_MS, Type.LONG, REGEX_TIMEOUT_MS_DEFAULT, Importance.MEDIUM);
 
     MongoSinkTopicConfig.BASE_CONFIG.configKeys().values().forEach(configDef::define);
     return configDef;

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
@@ -300,6 +300,43 @@ class MongoSinkConfigTest {
   }
 
   @Test
+  @DisplayName("test topic regex with overrides avoids CWE-1333 ReDOS")
+  void testTopicRegexWithOverridesReDOS() {
+    String safeRegex = "(a+)+";
+    String unsafeRegex = "(a+)+b";
+    
+    // Create a string that will definitely cause a timeout with the unsafe regex,
+    // but not with the safe regex
+    // The string contains only 'a's but the unsafe regex requires a 'b' at the end
+    // This will cause catastrophic backtracking.
+    StringBuilder input = new StringBuilder();
+    for (int i = 0; i < 1000000; i++) {
+      input.append("a");
+    }
+    String topicOverride = input.toString();
+
+    MongoSinkConfig cfg =
+        createSinkConfig(
+            format(
+                "{'%s': '%s', '%s': 'otherDB', '%s': 'coll2'}",
+                TOPICS_REGEX_CONFIG,
+                safeRegex,
+                createOverrideKey(topicOverride, DATABASE_CONFIG),
+                createOverrideKey(topicOverride, COLLECTION_CONFIG)));
+    assertPattern("(a+)+", cfg.getTopicRegex().orElse(EMPTY_PATTERN));
+    assertEquals("otherDB", cfg.getMongoSinkTopicConfig(topicOverride).getString(DATABASE_CONFIG));
+    assertEquals("coll2", cfg.getMongoSinkTopicConfig(topicOverride).getString(COLLECTION_CONFIG));
+    ConfigException exception = assertThrows(
+        ConfigException.class,
+        () ->
+            createSinkConfig(
+                format(
+                    "{'%s': '%s', '%s': 'made up'}",
+                    TOPICS_REGEX_CONFIG, unsafeRegex, createOverrideKey(topicOverride, KEY_PROJECTION_TYPE_CONFIG))));
+    assertTrue(exception.getMessage().contains("Regex match operation timed out after "));
+  }
+
+  @Test
   @DisplayName("test K/V projection with invalid projection type")
   void testProjectionWithInvalidProjectionTypes() {
     assertAll(


### PR DESCRIPTION
Summary:
Potential ReDOS vulnerability from user-supplied data in java.util.regex When topics.regex and topic.override.<topic_name>.<property> are both provided, the sink connector matches <topic_name> with the topics.regex. Here there is a ReDOS vulnerability - CWE-1333. Switch to RegexUtils.matches, which enforces a timeout, and uses an executor thread.

Testing:
Added unit test with:
1. A safe regex and topic override which does not cause ReDOS.
2. An unsafe regex and topic override, which would have caused ReDOS, but times out instead.

Backward compatible: Yes