### PR TITLE
CC-33219 | Added new configuration remove.field.on.schema.mismatch

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -534,6 +534,16 @@ public class MongoSourceConfig extends AbstractConfig {
   public static final String OVERRIDE_ERRORS_TOLERANCE_DOC =
       "Use this property if you would like to configure the connector's error handling behavior differently from the Connect framework's.";
 
+  public static final String REMOVE_FIELD_ON_SCHEMA_MISMATCH_CONFIG = "remove.field.on.schema.mismatch";
+  public static final boolean REMOVE_FIELD_ON_SCHEMA_MISMATCH_DEFAULT = true;
+  private static final String REMOVE_FIELD_ON_SCHEMA_MISMATCH_DOC =
+      "If true, remove fields from the document that are not present in the schema. "
+          + "Otherwise, throw an error or send the documents to the DLQ depending on the value of "
+          + ERRORS_TOLERANCE_CONFIG
+          + " being set to ALL or NONE respectively.";
+  private static final String REMOVE_FIELD_ON_SCHEMA_MISMATCH_DISPLAY =
+      "Remove Field on Schema Mismatch";
+
   public static final String ERRORS_LOG_ENABLE_CONFIG = "errors.log.enable";
   public static final String ERRORS_LOG_ENABLE_DISPLAY = "Log Errors";
   public static final boolean ERRORS_LOG_ENABLE_DEFAULT = false;
@@ -1456,6 +1466,18 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.SHORT,
         ERRORS_TOLERANCE_DISPLAY);
+
+    configDef.define(
+        REMOVE_FIELD_ON_SCHEMA_MISMATCH_CONFIG,
+        Type.BOOLEAN,
+        REMOVE_FIELD_ON_SCHEMA_MISMATCH_DEFAULT,
+        Importance.MEDIUM,
+        REMOVE_FIELD_ON_SCHEMA_MISMATCH_DOC,
+        group,
+        ++orderInGroup,
+        Width.SHORT,
+        REMOVE_FIELD_ON_SCHEMA_MISMATCH_DISPLAY
+    );
 
     configDef.define(
         ERRORS_LOG_ENABLE_CONFIG,

--- a/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
@@ -27,6 +27,7 @@ import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_AWAIT_TIME
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_MAX_BATCH_SIZE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.PUBLISH_FULL_DOCUMENT_ONLY_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.PUBLISH_FULL_DOCUMENT_ONLY_TOMBSTONE_ON_DELETE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.REMOVE_FIELD_ON_SCHEMA_MISMATCH_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.StartupConfig.StartupMode.COPY_EXISTING;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.StartupConfig.StartupMode.TIMESTAMP;
 import static com.mongodb.kafka.connect.source.MongoSourceTask.COPY_KEY;
@@ -313,6 +314,9 @@ final class StartedMongoSourceTask implements AutoCloseable {
       @Nullable final BsonDocument valueDocument) {
 
     try {
+      if (!sourceConfig.getBoolean(REMOVE_FIELD_ON_SCHEMA_MISMATCH_CONFIG)) {
+        valueSchemaAndValueProducer.checkForExtraFields(valueDocument);
+      }
       SchemaAndValue keySchemaAndValue = keySchemaAndValueProducer.get(keyDocument);
       SchemaAndValue valueSchemaAndValue = valueSchemaAndValueProducer.get(valueDocument);
       return Optional.of(

--- a/src/main/java/com/mongodb/kafka/connect/source/producer/AvroSchemaAndValueProducer.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/producer/AvroSchemaAndValueProducer.java
@@ -38,4 +38,9 @@ final class AvroSchemaAndValueProducer implements SchemaAndValueProducer {
   public SchemaAndValue get(final BsonDocument changeStreamDocument) {
     return bsonValueToSchemaAndValue.toSchemaAndValue(schema, changeStreamDocument);
   }
+
+  @Override
+  public void checkForExtraFields(final BsonDocument changeStreamDocument) {
+    bsonValueToSchemaAndValue.checkForExtraFields(schema, changeStreamDocument);
+  }
 }

--- a/src/main/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducer.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducer.java
@@ -22,4 +22,7 @@ import org.bson.BsonDocument;
 
 public interface SchemaAndValueProducer {
   SchemaAndValue get(BsonDocument changeStreamDocument);
+  default void checkForExtraFields(final BsonDocument changeStreamDocument) {
+    // no-op
+  }
 }

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValue.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValue.java
@@ -298,7 +298,7 @@ public class BsonValueToSchemaAndValue {
           (key, value) -> {
             Field field = schema.field(key);
             if (field == null) {
-              throw extraFieldException(key, doc);
+              throw extraFieldException(key);
             }
             checkForExtraFields(field.schema(), value);
           }
@@ -346,8 +346,7 @@ public class BsonValueToSchemaAndValue {
     return new DataException(format("Missing field '%s'", field.name()));
   }
 
-  private DataException extraFieldException(final String key, final BsonDocument value) {
-    return new DataException(
-        format("Extra field '%s' in: '%s'", key, value.toJson(jsonWriterSettings)));
+  private DataException extraFieldException(final String key) {
+    return new DataException(format("The field '%s' is not defined in the Schema.", key));
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValue.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValue.java
@@ -60,6 +60,7 @@ import org.bson.codecs.Codec;
 import org.bson.codecs.EncoderContext;
 import org.bson.io.BasicOutputBuffer;
 import org.bson.json.JsonWriterSettings;
+import org.bson.BsonArray;
 
 public class BsonValueToSchemaAndValue {
   private static final Codec<BsonValue> BSON_VALUE_CODEC = new BsonValueCodec();
@@ -287,6 +288,38 @@ public class BsonValueToSchemaAndValue {
     return new SchemaAndValue(schema, structValue);
   }
 
+  public void checkForExtraFields(final Schema schema, final BsonValue bsonValue) {
+    if (schema.isOptional() && bsonValue.isNull()) {
+      return;
+    }
+    if (schema.type() == Type.STRUCT && bsonValue.isDocument()) {
+      BsonDocument doc = bsonValue.asDocument();
+      doc.forEach(
+          (key, value) -> {
+            Field field = schema.field(key);
+            if (field == null) {
+              throw extraFieldException(key, doc);
+            }
+            checkForExtraFields(field.schema(), value);
+          }
+      );
+    } else if (schema.type() == Type.ARRAY && bsonValue.isArray()) {
+      BsonArray array = bsonValue.asArray();
+      array.forEach(
+          value -> {
+            checkForExtraFields(schema.valueSchema(), value);
+          }
+      );
+    } else if (schema.type() == Type.MAP && bsonValue.isDocument()) {
+      BsonDocument doc = bsonValue.asDocument();
+      doc.forEach(
+          (key, value) -> {
+            checkForExtraFields(schema.valueSchema(), value);
+          }
+      );
+    }
+  }
+
   private SchemaAndValue booleanToSchemaAndValue(final Schema schema, final BsonValue bsonValue) {
     if (!bsonValue.isBoolean()) {
       throw unexpectedBsonValueType(Schema.Type.BOOLEAN, bsonValue);
@@ -311,5 +344,10 @@ public class BsonValueToSchemaAndValue {
 
   private DataException missingFieldException(final Field field, final BsonDocument value) {
     return new DataException(format("Missing field '%s'", field.name()));
+  }
+
+  private DataException extraFieldException(final String key, final BsonDocument value) {
+    return new DataException(
+        format("Extra field '%s' in: '%s'", key, value.toJson(jsonWriterSettings)));
   }
 }

--- a/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
@@ -28,6 +28,8 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.math.BigDecimal;
 import java.util.Base64;
@@ -39,6 +41,8 @@ import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.DataException;
+import org.bson.BsonInt32;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -147,6 +151,92 @@ public class SchemaAndValueProducerTest {
         new AvroSchemaAndValueProducer(DEFAULT_AVRO_VALUE_SCHEMA, EXTENDED_JSON_WRITER_SETTINGS);
     assertSchemaAndValueEquals(
         expectedExtendedValue, extendedJsonValueProducer.get(CHANGE_STREAM_DOCUMENT));
+  }
+
+  @Test
+  @DisplayName("test extra fields not in schema")
+  void testExtraFieldsNotInSchema() {
+    String complexJsonSchema = "{"
+        + "\"type\": \"record\","
+        + "\"name\": \"ComplexRecord\","
+        + "\"fields\": ["
+        + "  {"
+        + "    \"name\": \"nestedDocument\","
+        + "    \"type\": {"
+        + "      \"type\": \"record\","
+        + "      \"name\": \"NestedDocument\","
+        + "      \"fields\": ["
+        + "        {\"name\": \"field1\", \"type\": \"string\"},"
+        + "        {\"name\": \"field2\", \"type\": \"int\"}"
+        + "      ]"
+        + "    }"
+        + "  },"
+        + "  {"
+        + "    \"name\": \"arrayWithDocuments\","
+        + "    \"type\": {"
+        + "      \"type\": \"array\","
+        + "      \"items\": {"
+        + "        \"type\": \"record\","
+        + "        \"name\": \"ArrayItem\","
+        + "        \"fields\": ["
+        + "          {\"name\": \"itemField1\", \"type\": \"string\"},"
+        + "          {\"name\": \"itemField2\", \"type\": \"boolean\"}"
+        + "        ]"
+        + "      }"
+        + "    }"
+        + "  }"
+        + "]"
+        + "}";
+
+    String complexJsonValue = "{\n" +
+        "  \"nestedDocument\": {\n" +
+        "    \"field1\": \"example string\",\n" +
+        "    \"field2\": 123\n" +
+        "  },\n" +
+        "  \"arrayWithDocuments\": [\n" +
+        "    {\n" +
+        "      \"itemField1\": \"item1\",\n" +
+        "      \"itemField2\": true\n" +
+        "    },\n" +
+        "    {\n" +
+        "      \"itemField1\": \"item2\",\n" +
+        "      \"itemField2\": false\n" +
+        "    }\n" +
+        "  ]\n" +
+        "}";
+
+    BsonDocument fullDocument = BsonDocument.parse(complexJsonValue);
+
+    SchemaAndValueProducer inferSchemaAndValueProducer =
+        new InferSchemaAndValueProducer(SIMPLE_JSON_WRITER_SETTINGS);
+    assertDoesNotThrow(
+        () -> inferSchemaAndValueProducer.checkForExtraFields(fullDocument));
+
+    SchemaAndValueProducer avroSchemaAndValueProducer =
+        new AvroSchemaAndValueProducer(complexJsonSchema, SIMPLE_JSON_WRITER_SETTINGS);
+    assertDoesNotThrow(
+        () -> avroSchemaAndValueProducer.checkForExtraFields(fullDocument));
+
+    fullDocument.get("arrayWithDocuments").asArray().get(1).asDocument().append("extraField", new BsonInt32(1));
+    assertThrows(
+        DataException.class,
+        () -> avroSchemaAndValueProducer.checkForExtraFields(fullDocument));
+    fullDocument.get("arrayWithDocuments").asArray().get(1).asDocument().remove("extraField");
+
+    fullDocument.get("nestedDocument").asDocument().append("extraField", new BsonInt32(1));
+    assertThrows(
+        DataException.class,
+        () -> avroSchemaAndValueProducer.checkForExtraFields(fullDocument));
+    fullDocument.get("nestedDocument").asDocument().remove("extraField");
+
+    fullDocument.append("extraField", new BsonInt32(1));
+    assertThrows(
+        DataException.class,
+        () -> avroSchemaAndValueProducer.checkForExtraFields(fullDocument));
+    fullDocument.remove("extraField");
+
+    assertDoesNotThrow(
+        () -> avroSchemaAndValueProducer.checkForExtraFields(fullDocument));
   }
 
   @Test


### PR DESCRIPTION
<!--  
Thanks for sending the PR, please make sure, your code adheres to our coding guidelines at: https://kafka.apache.org/coding-guide
Please reference the JIRA ticket if applicable in the title of the PR.
For example: 
[CC-XXXX] Add support for simple incrementing pagination mode

Exceptions can be made for small fixes, typos using the following pattern:
[HOTFIX] Update cc-docker version for production release
-->

## What is the purpose of the change
As part of INIT-9095, We want to handle fields in the value document which are not present and in the schema.
The current behaviour is we remove those fields before putting record in the topic.
We want it those documents to follow one of the following behaviour,
1. Current behaviour - removing extra fields
2. Fail the connector due to the document having extra fields
3. Send such documents in the DLQ

<!--
Please clarify why the changes are needed. For instance,
- If you propose a new API/ feature, clarify the use case. 
- If you fix a bug, you can clarify why it is a bug.
-->

## Brief change log
Introduced a new config named `remove.field.on.schema.mismatch`.
The default value is true.
When True -> Follow the current behaviour.
When False ->
1. Error Tolerance Config value -> NONE - Fail the connector
2. Error Tolerance Config value -> ALL - Send to DLQ

Also, added an error mapping for failure case.

mongo-kafka PR (This PR) - To introduce configuration and use it in the connector.
[mongo-kafka-private PR](https://github.com/confluentinc/mongo-kafka-private/pull/152) - To expose the configuration on cloud UI.
<!--
Please capture a brief summary of important changes introduced as part of this PR, the idea here is to add a brief description to help reviewers understand the changes. 
You may also reference any one-pagers related to design, for example:
- Introduces component/class XXX which contains most of the all logic for feature YYYY
- Introduce configs to selectively disable the feature as needed
- Minor refactoring for XXX
 
Please ensure that we don't end up logging any sensitive information as part of this change, such as passwords, tokens, etc.
-->

## Change type

Please check any boxes [x] if the answer is "yes".

- [ ] Bug fix
- [x] New feature
- [ ] Deployment related change or Vulnerability fix
- [x] Documentation update

## Testing

Please check any boxes [x] if the answer is "yes".

- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

Added unit test testExtraFieldsNotInSchema which validates for positive and negative cases.
Manually verified all three scenarios by using playground & on Devel canary 5.

Common Configuration used for testing, including schema:
```json
"startup.mode": "copy_existing",
"output.schema.value": "{ \"type\": \"record\", \"name\": \"ComplexRecord\",   \"fields\": [  { \"name\": \"_id\", \"type\": \"string\" }, {   \"name\": \"nestedDocument\",   \"type\": { \"type\": \"record\", \"name\": \"NestedDocument\", \"fields\": [   { \"name\": \"field1\", \"type\": \"string\" },   { \"name\": \"field2\", \"type\": \"int\" } ]   } }, {   \"name\": \"arrayWithDocuments\",   \"type\": { \"type\": \"array\", \"items\": {   \"type\": \"record\",   \"name\": \"ArrayItem\",   \"fields\": [ { \"name\": \"itemField1\", \"type\": \"string\" }, { \"name\": \"itemField2\", \"type\": \"boolean\" }   ] }   } }, {   \"name\": \"mapWithNestedDocument\",   \"type\": { \"type\": \"map\", \"values\": {   \"type\": \"record\",   \"name\": \"MapValue\",   \"fields\": [ { \"name\": \"nestedKey1\", \"type\": \"string\" }, { \"name\": \"nestedKey2\", \"type\": \"double\" }   ] }   } }   ] }",
"publish.full.document.only": "true",
"output.schema.infer.value": "false",
```

Input message used for testing, including extra fields(not defined in the schema) :
```json
{
    "_id": {
        "$oid": "6836e8f8e815ad78921aeb49"
    },
    "nestedDocument": {
        "field1": "example-string",
        "field2": {
            "$numberInt": "42"
        },
        "extraField1": "1"
    },
    "arrayWithDocuments": [
        {
            "itemField1": "item-1",
            "itemField2": true,
            "extraField2": {
                "$numberInt": "2"
            }
        },
        {
            "itemField1": "item-2",
            "itemField2": false
        }
    ],
    "mapWithNestedDocument": {
        "key1": {
            "nestedKey1": "value-1",
            "nestedKey2": {
                "$numberDouble": "3.14"
            }
        },
        "key2": {
            "nestedKey1": "value-2",
            "nestedKey2": {
                "$numberDouble": "2.71"
            },
            "extraField3": {
                "$numberDouble": "3.0"
            }
        }
    },
    "extraField4": {
        "dummy": {
            "$numberInt": "4"
        }
    }
}
```

### 1. Default Behaviour - Removing extra fields
    
Configuraiton:
```json
"remove.field.on.schema.mismatch": "true",
"mongo.errors.tolerance": "NONE",
"errors.tolerance": "none"
```

Output Message:
![image](https://github.com/user-attachments/assets/d6419091-31b5-4fec-9022-226e307c0d49)

Result:
Got the message in the topic with only the fields defined in the schema (extra fields removed) as expected.

Also tried for the documents with:
Missing fields from schema - Failed as expected.
Exact match with schema - Got the document as it is as expected. 

### 2. Send in DLQ

Configuration:
```json
"remove.field.on.schema.mismatch": "false",
"mongo.errors.tolerance": "ALL",
"errors.tolerance": "all",
"mongo.errors.deadletterqueue.topic.name": "smstest.errors"
```

Output Message:
![image](https://github.com/user-attachments/assets/5d4b6ae7-ad60-4381-9e4e-77f9bcad5e9e)
Result:
Message went to DLQ as it is in a string format as expected.

Also tried for the documents with:
Combinations of extra fields within nested document, array and map - went to DLQ as expected.

### 3. Fail the Connector

Configuration:
```json
"remove.field.on.schema.mismatch": "false",
"mongo.errors.tolerance": "NONE",
"errors.tolerance": "none"
```

Output Message:
<img width="1164" alt="image" src="https://github.com/user-attachments/assets/fd7321c2-bc19-4500-947b-a977ca708be0" />
![image](https://github.com/user-attachments/assets/458bab37-1bd2-4c75-af17-7a7a4d070144)
Error Map User message: The field 'extraField' in the document is not defined in the Schema. Check out 'remove.field.on.schema.mismatch' configuration in the connector documentation for more information.

Result:
Failed the connector in case of extra fields as expected.

### Performance Testing

Created connectors with configuration "remove.field.on.schema.mismatch" as true and false, compared their performance with more than 10k documents having more than 100 nested fields.

Result:
<img width="1703" alt="image" src="https://github.com/user-attachments/assets/75bb2da7-199a-49f5-9288-b11e161f7532" />
Got the similar result in both cases, so it is not degrading the performance.

<!-- 
Please add a brief description of tests that were run to verify this change.

You may pick either of the following options

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
- *Added integration tests for feature XXX*
- *Extended integration test for YYY*
- *Added test methodName which validates for positive and negative cases*
- *Manually verified the change by running a local connect cluster ..*
-->

## Monitoring
We can see and set the exposed configuration over UI.
We can also monitor stats for the configuration via DB, to monitor how many customers are using this. 
<!--
Please add a brief description of how this change can be monitored in production, if applicable.
-->

## Release Plan
Will be released in regular cloud release.

### Steps
- Merged the [reviewed and approved PR](https://github.com/confluentinc/mongo-kafka-private/pull/152) into the master branch of repo.
- Will update cache-version.env file in cc-docker-connect to update the version for MongoDB Atlas Source Connector.

<!--- 
Please mention the release plan if applicable. Are you targeting a path, major or minor release?
-->

## Risk Assessment and Mitigation
The default value for the configuration is `true`, which keeps current behaviour and is well verified.
The added code will only be invoked if the the value of configuration is `false`.
1. If something breaks when configuration is `false` - We can have quick LD override.
2. In worst case, if existing behaviour breaks, we need to revert the release.
<!-- 
If this is a high risk change, please add a brief description of what could go wrong, and the mitigation / rollback strategy 
-->