### PR TITLE
CC-32392 | Used RegexUtils instead java.util to fix ReDOS issue

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,7 @@ extra.apply {
     set("confluentVersion", "6.0.1")
     set("scalaVersion", "2.13")
     set("curatorVersion", "2.9.0")
-    set("connectUtilsVersion", "0.4+")
+    set("connectUtilsVersion", "1.1.0")
 }
 
 val mongoDependencies: Configuration by configurations.creating
@@ -73,6 +73,7 @@ dependencies {
     implementation("org.apache.kafka:connect-api:${project.extra["kafkaVersion"]}")
     implementation("org.mongodb:mongodb-driver-sync:${project.extra["mongodbDriverVersion"]}")
     implementation("org.apache.avro:avro:${project.extra["avroVersion"]}")
+    implementation("com.github.jcustenborder.kafka.connect:connect-utils:${project.extra["connectUtilsVersion"]}")
 
     mongoDependencies("org.mongodb:mongodb-driver-sync:${project.extra["mongodbDriverVersion"]}")
 
@@ -89,7 +90,6 @@ dependencies {
 
     // Integration Tests
     testImplementation("org.apache.curator:curator-test:${project.extra["curatorVersion"]}")
-    testImplementation("com.github.jcustenborder.kafka.connect:connect-utils:${project.extra["connectUtilsVersion"]}")
     testImplementation(platform("io.confluent:kafka-schema-registry-parent:${project.extra["confluentVersion"]}"))
     testImplementation(group = "com.google.guava", name = "guava")
     testImplementation(group = "io.confluent", name = "kafka-schema-registry")

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoCopyDataManager.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoCopyDataManager.java
@@ -17,6 +17,7 @@ package com.mongodb.kafka.connect.source;
 
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COLLECTION_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.DATABASE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.REGEX_TIMEOUT_MS;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
@@ -30,8 +31,9 @@ import java.util.Optional;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import org.apache.kafka.connect.errors.ConnectException;
@@ -44,6 +46,7 @@ import org.bson.BsonType;
 import org.bson.RawBsonDocument;
 import org.bson.conversions.Bson;
 
+import com.github.jcustenborder.kafka.connect.utils.RegexUtils;
 import com.mongodb.MongoNamespace;
 import com.mongodb.client.MongoClient;
 
@@ -176,9 +179,22 @@ class MongoCopyDataManager implements AutoCloseable {
     }
 
     if (!namespacesRegex.isEmpty()) {
-      Predicate<String> predicate = Pattern.compile(namespacesRegex).asPredicate();
+      Pattern pattern = Pattern.compile(namespacesRegex);
+      long regexTimeout = sourceConfig.getLong(REGEX_TIMEOUT_MS);
       namespaces =
-          namespaces.stream().filter(n -> predicate.test(n.getFullName())).collect(toList());
+          namespaces.stream().filter(n -> {
+            try {
+              return RegexUtils.find(pattern, n.getFullName(), regexTimeout);
+            } catch (TimeoutException e) {
+              throw new ConnectException(
+                  "Regex replacement operation timed out after " + regexTimeout + "ms", e);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+              throw new ConnectException("Thread was interrupted during regex replacement", e);
+            } catch (ExecutionException e) {
+              throw new ConnectException("Error during regex replacement", e);
+            }
+          }).collect(toList());
     }
 
     return namespaces;

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -448,6 +448,14 @@ public class MongoSourceConfig extends AbstractConfig {
           + "\nIt is an equivalent replacement for the deprecated 'copy.existing.namespace.regex'.";
   static final String STARTUP_MODE_COPY_EXISTING_NAMESPACE_REGEX_DEFAULT = EMPTY_STRING;
 
+  public static final String REGEX_TIMEOUT_MS = "regex.timeout.ms";
+  public static final long REGEX_TIMEOUT_MS_DEFAULT = 1000L;
+  private static final String REGEX_TIMEOUT_MS_DOC =
+      "Timeout in milliseconds for any regex operation. This controls how long the connector will "
+          + "wait for regex pattern compilation, matching, replacement, or any other regex-related "
+          + "operation to complete before timing out.";
+  private static final String REGEX_TIMEOUT_MS_DISPLAY = "Regex Timeout (ms)";
+
   static final String STARTUP_MODE_COPY_EXISTING_ALLOW_DISK_USE_CONFIG =
       "startup.mode.copy.existing.allow.disk.use";
   private static final String STARTUP_MODE_COPY_EXISTING_ALLOW_DISK_USE_DISPLAY =
@@ -1359,6 +1367,18 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         STARTUP_MODE_COPY_EXISTING_NAMESPACE_REGEX_DISPLAY);
+
+    configDef.define(
+        REGEX_TIMEOUT_MS,
+        ConfigDef.Type.LONG,
+        REGEX_TIMEOUT_MS_DEFAULT,
+        ConfigDef.Range.atLeast(1),
+        ConfigDef.Importance.LOW,
+        REGEX_TIMEOUT_MS_DOC,
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.SHORT,
+        REGEX_TIMEOUT_MS_DISPLAY);
 
     configDef.define(
         STARTUP_MODE_COPY_EXISTING_ALLOW_DISK_USE_CONFIG,

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -449,7 +449,7 @@ public class MongoSourceConfig extends AbstractConfig {
   static final String STARTUP_MODE_COPY_EXISTING_NAMESPACE_REGEX_DEFAULT = EMPTY_STRING;
 
   public static final String REGEX_TIMEOUT_MS = "regex.timeout.ms";
-  public static final long REGEX_TIMEOUT_MS_DEFAULT = 1000L;
+  public static final long REGEX_TIMEOUT_MS_DEFAULT = 100L;
   private static final String REGEX_TIMEOUT_MS_DOC =
       "Timeout in milliseconds for any regex operation. This controls how long the connector will "
           + "wait for regex pattern compilation, matching, replacement, or any other regex-related "

--- a/src/test/java/com/mongodb/kafka/connect/source/MongoCopyDataManagerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/MongoCopyDataManagerTest.java
@@ -20,6 +20,7 @@ import static com.mongodb.kafka.connect.source.MongoSourceConfig.COLLECTION_CONF
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COPY_EXISTING_ALLOW_DISK_USE_DEFAULT;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.DATABASE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.PIPELINE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.REGEX_TIMEOUT_MS;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.STARTUP_MODE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.STARTUP_MODE_COPY_EXISTING_ALLOW_DISK_USE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.STARTUP_MODE_COPY_EXISTING_NAMESPACE_REGEX_CONFIG;
@@ -36,6 +37,8 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -48,10 +51,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -477,6 +482,52 @@ class MongoCopyDataManagerTest {
       sleep();
       copyExistingDataManager.poll();
     }
+  }
+
+  @Test
+  public void testRegexReplacementWithTimeout() {
+    StringBuilder input = new StringBuilder();
+    for (int i = 0; i < 10000; i++) {
+      input.append("a");
+    }
+    String inputString = input.toString();
+
+    Map<String, String> props = new HashMap<>();
+    props.put(STARTUP_MODE_CONFIG, StartupMode.COPY_EXISTING.propertyValue());
+    props.put(DATABASE_CONFIG, inputString);
+    props.put(COLLECTION_CONFIG, inputString);
+    props.put(STARTUP_MODE_COPY_EXISTING_NAMESPACE_REGEX_CONFIG, "(([a.]+)+)Z");
+    props.put(REGEX_TIMEOUT_MS, "100");
+    MongoSourceConfig sourceConfig = createSourceConfig(props);
+
+    ConnectException exception = assertThrows(ConnectException.class,
+        () -> new MongoCopyDataManager(sourceConfig, mongoClient));
+    assertInstanceOf(TimeoutException.class, exception.getCause());
+  }
+
+  @Test
+  public void testRegexReplacementWithInterruption() throws InterruptedException {
+    StringBuilder input = new StringBuilder();
+    for (int i = 0; i < 10000; i++) {
+      input.append("a");
+    }
+    String inputString = input.toString();
+
+    Map<String, String> props = new HashMap<>();
+    props.put(STARTUP_MODE_CONFIG, StartupMode.COPY_EXISTING.propertyValue());
+    props.put(DATABASE_CONFIG, inputString);
+    props.put(COLLECTION_CONFIG, inputString);
+    props.put(STARTUP_MODE_COPY_EXISTING_NAMESPACE_REGEX_CONFIG, "(([a.]+)+)Z");
+    MongoSourceConfig sourceConfig = createSourceConfig(props);
+
+    Thread copyDataManagerThread = new Thread(() -> {
+      ConnectException e = assertThrows(ConnectException.class, () -> new MongoCopyDataManager(sourceConfig, mongoClient));
+      assertInstanceOf(InterruptedException.class, e.getCause(), "Expected InterruptedException as cause");
+      assertTrue(Thread.currentThread().isInterrupted(), "Thread should be interrupted");
+    });
+    copyDataManagerThread.start();
+    copyDataManagerThread.interrupt();
+    copyDataManagerThread.join(2000);
   }
 
   private void sleep(final int millis) {


### PR DESCRIPTION
<!--  
Thanks for sending the PR, please make sure, your code adheres to our coding guidelines at: https://kafka.apache.org/coding-guide
Please reference the JIRA ticket if applicable in the title of the PR.
For example: 
[CC-XXXX] Add support for simple incrementing pagination mode

Exceptions can be made for small fixes, typos using the following pattern:
[HOTFIX] Update cc-docker version for production release
-->

## What is the purpose of the change
For CC-32392, We want to handle ReDOS vulnerability from user supplied data in MongoCopyDataManager.java

<!--
Please clarify why the changes are needed. For instance,
- If you propose a new API/ feature, clarify the use case. 
- If you fix a bug, you can clarify why it is a bug.
-->

## Brief change log
We have RegexUtils defined [in this PR](https://github.com/confluentinc/connector-utils/pull/25).
Used that RegexUtils instead of java.util library directly, to have TimeOut and Interrupt Exceptions while regex matching.
For that, Introduced a new configuration regex.timeout.ms with default value of 100 ms, hardcoded it to 100ms in template.
Created an error mapping for Regex Timeout.

<!--
Please capture a brief summary of important changes introduced as part of this PR, the idea here is to add a brief description to help reviewers understand the changes. 
You may also reference any one-pagers related to design, for example:
- Introduces component/class XXX which contains most of the all logic for feature YYYY
- Introduce configs to selectively disable the feature as needed
- Minor refactoring for XXX
 
Please ensure that we don't end up logging any sensitive information as part of this change, such as passwords, tokens, etc.
-->

## Change type

Please check any boxes [x] if the answer is "yes".

- [ ] Bug fix
- [ ] New feature
- [x] Deployment related change or Vulnerability fix
- [ ] Documentation update

## Testing

Please check any boxes [x] if the answer is "yes".

- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

Added tests testRegexReplacementWithTimeout and testRegexReplacementWithInterruption which validates for Timeout and Interrupt exceptions.

Error Map Id: 12358
{"Connector Type":"MongoDbAtlasSource","Error Message":"Regex operation timed out after","User Message":"Regex operation timed out. Please fix the provided regex or reach out to Confluent support."}
<!-- 
Please add a brief description of tests that were run to verify this change.

You may pick either of the following options

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
- *Added integration tests for feature XXX*
- *Extended integration test for YYY*
- *Added test methodName which validates for positive and negative cases*
- *Manually verified the change by running a local connect cluster ..*
-->

## Monitoring

<!--
Please add a brief description of how this change can be monitored in production, if applicable.
-->

## Release Plan
Will be released in regular cloud release.

### Steps
- Will merge configuration chages PR into the master branch of mongo-kafka-private repository.
- Will update cache-version.env file in cc-docker-connect to update the version for MongoDB Atlas Source Connector.

<!--- 
Please mention the release plan if applicable. Are you targeting a path, major or minor release?
-->

## Risk Assessment and Mitigation
The risk is low here, since we have already tested the utils and using the same in other connectors.
<!-- 
If this is a high risk change, please add a brief description of what could go wrong, and the mitigation / rollback strategy 
-->

## For CAB review:

What is being changed?
-> Done

What testing has been done (unit, integration, performance, etc.)?
-> Done

Has the change been reviewed and approved by a senior engineer? Have all review comments been addressed?
-> Approved by Aniket from Connect & Ritishkumar from Appsec

Are there any backward-incompatible changes? If so, how is this safely rolled out?
-> no backward-incompatible changes.

Is the change secure (e.g., see if sensitive data is being logged or exposed)?
-> It is secure.

What is the blast radius of this change? (e.g., specific set of connectors or clusters, entire Connect, etc.)
-> All cloud MongoDBAtlasSource connectors

How is the rollout being done? (e.g., soak in devel, staged rollout, any exceptions from the normal rollout SOP)
-> Normal cloud release

How are we validating that the change works as expected (e.g., using dashboards, alerts, logs, etc.). Who is responsible for this validation?
-> We will check by trying the regex that takes more than 100ms, and see if we are getting the Timeout Exception. And User facing error as per the error map.

Is the recovery/rollback plan documented and tested? Is it deviating from the normal SOP? How long would a rollback take?
-> We can use LD flag to control the value of `regex.timeout.utils` for recovery, For roll back to the last version of connector in cc-docker and perform a fleet wide roll.

Is sufficient monitoring and observability in place?
-> 

Are documentation updates done (user facing, operational runbooks, APIs, etc.)?
-> Since this is not exposed to customers, no documentation changes has been done. We have created an error map for Timeout exception.

Are the relevant stakeholders been notified? (change owner, release owner, on-call)
-> SME Aniket & Appsec both have approved the PR.

Are there any follow-up tasks to be done after the release (e.g., cleanup)?
-> Nope

# Reference configs for repro
```
playground connector create-or-update --connector mongodb-source  << EOF
{
     "connector.class" : "com.mongodb.kafka.connect.MongoSourceConnector",
     "tasks.max" : "1",
     "connection.host": "cluster0.ltjyk49.mongodb.net",
     "connection.user": "ssonagara",
     "connection.password": "***Conf%****",
     "database":"inventory",
     "collection":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaac",
     "startup.mode.copy.existing.namespace.regex": "inventory.(a+)+b",
     "startup.mode":"copy_existing",
     "topic.prefix":"mongo",
     "output.format.value": "schema",
     "output.schema.infer.value": "true"
}
EOF
```