### PR TITLE
Fix non srv record validation

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/util/ConnectionValidator.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/ConnectionValidator.java
@@ -136,16 +136,13 @@ public final class ConnectionValidator {
       MongoClient mongoClient = MongoClients.create(mongoClientSettings);
 
       try {
-        if (connectionString.isSrvProtocol()) {
           if (!latch.await(latchTimeout, TimeUnit.MILLISECONDS)) {
             configValue.addErrorMessage("Unable to connect to the server.");
-            mongoClient.close();
           }
-        }
-        mongoClient.close();
       } catch (InterruptedException e) {
-        mongoClient.close();
         throw new ConnectException(e);
+      } finally {
+        mongoClient.close();;
       }
 
       if (configValue.errorMessages().isEmpty()) {

--- a/src/main/java/com/mongodb/kafka/connect/util/ConnectionValidator.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/ConnectionValidator.java
@@ -140,13 +140,9 @@ public final class ConnectionValidator {
           if (!latch.await(latchTimeout, TimeUnit.MILLISECONDS)) {
             configValue.addErrorMessage("Unable to connect to the server.");
             mongoClient.close();
-          } else {
-            mongoClient.close();
           }
-        } else {
-          configValue.addErrorMessage("Non-SRV protocol host is not supported");
-          mongoClient.close();
         }
+        mongoClient.close();
       } catch (InterruptedException e) {
         mongoClient.close();
         throw new ConnectException(e);

--- a/src/main/java/com/mongodb/kafka/connect/util/ConnectionValidator.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/ConnectionValidator.java
@@ -138,11 +138,11 @@ public final class ConnectionValidator {
       try {
           if (!latch.await(latchTimeout, TimeUnit.MILLISECONDS)) {
             configValue.addErrorMessage("Unable to connect to the server.");
+            mongoClient.close();
           }
       } catch (InterruptedException e) {
+        mongoClient.close();
         throw new ConnectException(e);
-      } finally {
-        mongoClient.close();;
       }
 
       if (configValue.errorMessages().isEmpty()) {


### PR DESCRIPTION
Part of - https://confluentinc.atlassian.net/browse/CC-35061
Removing validation for `Non-SRV protocol host is not supported` to support self managed MongoDB instance.
Tested it on devel, removing this no longer blocks non srv connection string (self managed connection).