### PR TITLE
Cherry Pick commits from version v1.14.x to v1.16.x

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
-# Global owner for repo
-* @mongodb/kafka-connector-contributors
+# See go/codeowners - automatically generated for confluentinc/mongo-kafka:
+*	@confluentinc/connect
+*	@confluentinc/connect-cloud

--- a/.semaphore/project.yml
+++ b/.semaphore/project.yml
@@ -1,0 +1,43 @@
+# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
+# template and configurations in service.yml.
+# Modifications in this file will be overwritten by generated content in the nightly run.
+# For more information, please refer to the page:
+# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
+apiVersion: v1alpha
+kind: Project
+metadata:
+  name: mongo-kafka
+  description: ""
+spec:
+  visibility: private
+  repository:
+    url: git@github.com:confluentinc/mongo-kafka.git
+    run_on:
+      - branches
+      - pull_requests
+    pipeline_file: .semaphore/semaphore.yml
+    integration_type: github_app
+    status:
+      pipeline_files:
+        - path: .semaphore/semaphore.yml
+          level: pipeline
+    whitelist:
+      branches:
+        - master
+        - main
+        - /^\d+\.\d+\.x$/
+        - /^gh-readonly-queue.*/
+  custom_permissions: true
+  debug_permissions:
+    - empty
+    - default_branch
+    - non_default_branch
+    - pull_request
+    - forked_pull_request
+    - tag
+  attach_permissions:
+    - default_branch
+    - non_default_branch
+    - pull_request
+    - forked_pull_request
+    - tag

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,65 @@
+# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
+# template and configurations in service.yml.
+# Any modifications made to ths file will be overwritten by the generated content in nightly runs.
+# For more information, please refer to the page:
+# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
+version: v1.0
+name: build-test-release
+agent:
+  machine:
+    type: s1-prod-ubuntu20-04-amd64-1
+
+fail_fast:
+  cancel:
+    when: "true"
+
+execution_time_limit:
+  hours: 1
+
+queue:
+  - when: "branch != 'master' and branch !~ 'v[0-9]+\\.[0-9]+\\.x'"
+    processing: parallel
+
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+      - sem-version java 8
+
+blocks:
+  - name: Test
+    dependencies: []
+    run:
+      # don't run the tests on non-functional changes...
+      when: "change_in('/', {exclude: ['/.deployed-versions/', '.github/']})"
+    task:
+      jobs:
+        - name: Test
+          commands:
+            - pip install confluent-release-tools -q
+            - . sem-pint
+            - ./gradlew test
+            - . cve-scan
+      epilogue:
+        always:
+          commands:
+            - . publish-test-results
+            - artifact push workflow target/test-results
+
+after_pipeline:
+  task:
+    agent:
+      machine:
+        type: s1-prod-ubuntu20-04-arm64-0
+    jobs:
+      - name: Metrics
+        commands:
+          - emit-ci-metrics -p -a test-results
+      - name: Publish Test Results
+        commands:
+          - test-results gen-pipeline-report
+      - name: SonarQube
+        commands:
+          - checkout
+          - sem-version java 11
+          - emit-sonarqube-data -a test-results

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -7,7 +7,7 @@ version: v1.0
 name: build-test-release
 agent:
   machine:
-    type: s1-prod-ubuntu20-04-amd64-1
+    type: s1-prod-ubuntu24-04-amd64-1
 
 fail_fast:
   cancel:
@@ -31,15 +31,16 @@ blocks:
     dependencies: []
     run:
       # don't run the tests on non-functional changes...
-      when: "change_in('/', {exclude: ['/.deployed-versions/', '.github/']})"
+      when: "change_in('/', {exclude: ['/.deployed-versions/', '.github/'], default_branch: 'master'})"
     task:
       jobs:
         - name: Test
           commands:
             - pip install confluent-release-tools -q
-            - . sem-pint
+            - . sem-pint -c
             - ./gradlew test
             - . cve-scan
+            - . cache-maven store
       epilogue:
         always:
           commands:
@@ -50,7 +51,7 @@ after_pipeline:
   task:
     agent:
       machine:
-        type: s1-prod-ubuntu20-04-arm64-0
+        type: s1-prod-ubuntu24-04-arm64-0
     jobs:
       - name: Metrics
         commands:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -228,32 +228,6 @@ tasks.withType<com.github.spotbugs.snom.SpotBugsTask> {
     reports.maybeCreate("xml").isEnabled = project.hasProperty("xmlReports.enabled")
 }
 
-// Spotless is used to lint and reformat source files.
-spotless {
-    java {
-        googleJavaFormat("1.12.0")
-        importOrder("java", "io", "org", "org.bson", "com.mongodb", "com.mongodb.kafka", "")
-        removeUnusedImports() // removes any unused imports
-        trimTrailingWhitespace()
-        endWithNewline()
-        indentWithSpaces()
-    }
-
-    kotlinGradle {
-        ktlint("0.31.0")
-        trimTrailingWhitespace()
-        indentWithSpaces()
-        endWithNewline()
-    }
-
-    format("extraneous") {
-        target("*.xml", "*.yml", "*.md")
-        trimTrailingWhitespace()
-        indentWithSpaces()
-        endWithNewline()
-    }
-}
-
 tasks.named("compileJava") {
     dependsOn(":spotlessApply")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,9 +76,11 @@ dependencies {
     implementation("com.github.jcustenborder.kafka.connect:connect-utils:${project.extra["connectUtilsVersion"]}")
 
     mongoDependencies("org.mongodb:mongodb-driver-sync:${project.extra["mongodbDriverVersion"]}")
+    mongoDependencies("com.github.jcustenborder.kafka.connect:connect-utils:${project.extra["connectUtilsVersion"]}")
 
     mongoAndAvroDependencies("org.mongodb:mongodb-driver-sync:${project.extra["mongodbDriverVersion"]}")
     mongoAndAvroDependencies("org.apache.avro:avro:${project.extra["avroVersion"]}")
+    mongoAndAvroDependencies("com.github.jcustenborder.kafka.connect:connect-utils:${project.extra["connectUtilsVersion"]}")
 
     // Unit Tests
     testImplementation(platform("org.junit:junit-bom:${project.extra["junitJupiterVersion"]}"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,7 @@ extra.apply {
     set("confluentVersion", "6.0.1")
     set("scalaVersion", "2.13")
     set("curatorVersion", "2.9.0")
-    set("connectUtilsVersion", "0.4+")
+    set("connectUtilsVersion", "1.1.0")
 }
 
 val mongoDependencies: Configuration by configurations.creating
@@ -73,6 +73,7 @@ dependencies {
     implementation("org.apache.kafka:connect-api:${project.extra["kafkaVersion"]}")
     implementation("org.mongodb:mongodb-driver-sync:${project.extra["mongodbDriverVersion"]}")
     implementation("org.apache.avro:avro:${project.extra["avroVersion"]}")
+    implementation("com.github.jcustenborder.kafka.connect:connect-utils:${project.extra["connectUtilsVersion"]}")
 
     mongoDependencies("org.mongodb:mongodb-driver-sync:${project.extra["mongodbDriverVersion"]}")
 
@@ -89,7 +90,6 @@ dependencies {
 
     // Integration Tests
     testImplementation("org.apache.curator:curator-test:${project.extra["curatorVersion"]}")
-    testImplementation("com.github.jcustenborder.kafka.connect:connect-utils:${project.extra["connectUtilsVersion"]}")
     testImplementation(platform("io.confluent:kafka-schema-registry-parent:${project.extra["confluentVersion"]}"))
     testImplementation(group = "com.google.guava", name = "guava")
     testImplementation(group = "io.confluent", name = "kafka-schema-registry")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,7 @@ extra.apply {
     set("mongodbDriverVersion", "[4.7,4.7.99]")
     set("kafkaVersion", "2.6.0")
     set("avroVersion", "1.9.2")
+    set("connectUtilsVersion", "1.1.0")
 
     // Testing dependencies
     set("junitJupiterVersion", "5.8.1")
@@ -63,7 +64,6 @@ extra.apply {
     set("confluentVersion", "6.0.1")
     set("scalaVersion", "2.13")
     set("curatorVersion", "2.9.0")
-    set("connectUtilsVersion", "1.1.0")
 }
 
 val mongoDependencies: Configuration by configurations.creating

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.java.installations.auto-download=false
 org.gradle.java.installations.fromEnv=JDK8,JDK17
-org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xmx1G --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xmx1G

--- a/service.yml
+++ b/service.yml
@@ -1,0 +1,13 @@
+name: mongo-kafka
+lang: java
+lang_version: 8
+git:
+  enable: true
+codeowners:
+  enable: true
+semaphore:
+  enable: true
+  pipeline_type: cp
+  cve_scan: true
+  extra_deploy_args: "-Dcloud -Pjenkins"
+  extra_build_args: "-Dcloud -Pjenkins"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+### service-bot sonarqube plugin managed file
+sonar.coverage.exclusions=**/test/**/*,**/tests/**/*,**/mock/**/*,**/mocks/**/*,**/*mock*,**/*test*
+sonar.coverage.jacoco.xmlReportPaths=**/jacoco.xml
+sonar.exclusions=**/*.pb.*,**/mk-include/**/*
+sonar.java.binaries=.
+sonar.language=java
+sonar.projectKey=mongo-kafka
+sonar.sources=.

--- a/src/integrationTest/java/com/mongodb/kafka/connect/ConnectorValidationIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/ConnectorValidationIntegrationTest.java
@@ -400,6 +400,12 @@ public final class ConnectorValidationIntegrationTest {
   }
 
   @Test
+  @DisplayName("Ensure source configuration validation handles invalid connection host in Url")
+  void testSourceConfigValidationInvalidConnectionUrl() {
+    assertInvalidSource(createSourceProperties("mongodb+srv://mongo:mongo@27017"));
+  }
+
+  @Test
   @DisplayName("Ensure source configuration validation works with invalid serverApi")
   void testSourceConfigValidationWithInvalidServerApi() {
     assumeFalse(isAtleastFiveDotZero(getMongoClient()));

--- a/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
@@ -903,8 +903,7 @@ public class MongoSourceTaskIntegrationTest extends MongoKafkaTestCase {
           task.logCapture.getEvents().stream()
               .filter(e -> e.getLevel().equals(Level.ERROR))
               .anyMatch(
-                  e ->
-                      e.getMessage().toString().contains("Exception creating Source record for:")));
+                  e -> e.getMessage().toString().contains("Exception creating Source record")));
 
       // Reset and test copy existing without logs
       task.stop();
@@ -922,7 +921,7 @@ public class MongoSourceTaskIntegrationTest extends MongoKafkaTestCase {
               .findFirst()
               .map(e -> e.getMessage().toString())
               .orElseGet(() -> "")
-              .contains("Exception creating Source record for:"));
+              .contains("Exception creating Source record"));
       task.stop();
     }
   }
@@ -956,7 +955,7 @@ public class MongoSourceTaskIntegrationTest extends MongoKafkaTestCase {
       insertMany(rangeClosed(4, 5), coll);
 
       Exception e = assertThrows(DataException.class, () -> getNextResults(task));
-      assertTrue(e.getMessage().contains("Exception creating Source record for:"));
+      assertTrue(e.getMessage().contains("Exception creating Source record"));
     }
   }
 

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordData.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordData.java
@@ -106,7 +106,12 @@ final class MongoProcessedSinkRecordData {
     } catch (Exception e) {
       exception = e;
       if (config.logErrors()) {
-        LOGGER.error("Unable to process record {}", sinkRecord, e);
+        LOGGER.error(
+            "Unable to process record in topic:{} at partition:{}, offset:{}",
+            sinkRecord.topic(),
+            sinkRecord.kafkaPartition(),
+            sinkRecord.kafkaOffset(),
+            e);
       }
       if (!(config.tolerateErrors() || config.tolerateDataErrors())) {
         throw e;

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
@@ -33,11 +33,14 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 import static org.apache.kafka.common.config.ConfigDef.Width;
+import com.github.jcustenborder.kafka.connect.utils.RegexUtils;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -74,6 +77,14 @@ public class MongoSinkConfig extends AbstractConfig {
   private static final String TOPICS_REGEX_DEFAULT = EMPTY_STRING;
   private static final String TOPICS_REGEX_DISPLAY = "Topics regex";
 
+  public static final String REGEX_TIMEOUT_MS = "regex.timeout.ms";
+  public static final long REGEX_TIMEOUT_MS_DEFAULT = 100L;
+  private static final String REGEX_TIMEOUT_MS_DOC =
+      "Timeout in milliseconds for any regex operation. This controls how long the connector will "
+          + "wait for regex pattern compilation, matching, replacement, or any other regex-related "
+          + "operation to complete before timing out.";
+  private static final String REGEX_TIMEOUT_MS_DISPLAY = "Regex Timeout (ms)";
+
   public static final String CONNECTION_URI_CONFIG = "connection.uri";
   private static final String CONNECTION_URI_DEFAULT = "mongodb://localhost:27017";
   private static final String CONNECTION_URI_DISPLAY = "MongoDB Connection URI";
@@ -93,6 +104,16 @@ public class MongoSinkConfig extends AbstractConfig {
           + "' and '"
           + TOPICS_CONFIG
           + "' are overridable.";
+
+  private static final String TOPIC_OVERRIDE_REGEX_TIMEOUT_ERROR_MESSAGE =
+      "Regex match operation timed out after %dms. "
+          + "A topic in one of the %s* configurations is causing the timeout when matching against %s. "
+          + "Please check your configurations.";
+
+  private static final String TOPIC_OVERRIDE_REGEX_ERROR_MESSAGE =
+      "Error during regex match: %s. "
+          + "A topic in one of the %s* configurations is causing an error when matching against %s. "
+          + "Please check your configurations.";
 
   static final String PROVIDER_CONFIG = "provider";
 
@@ -138,15 +159,35 @@ public class MongoSinkConfig extends AbstractConfig {
     // Process and validate overrides of regex values.
     if (topicsRegex.isPresent()) {
       Pattern topicRegex = topicsRegex.get();
+      long regexTimeoutDuration = getLong(REGEX_TIMEOUT_MS);
       originals.keySet().stream()
           .filter(k -> k.startsWith(TOPIC_OVERRIDE_PREFIX))
           .forEach(
               k -> {
                 String topic = k.substring(TOPIC_OVERRIDE_PREFIX.length()).split("\\.")[0];
-                if (!topicSinkConnectorConfigMap.containsKey(topic)
-                    && topicRegex.matcher(topic).matches()) {
-                  topicSinkConnectorConfigMap.put(
-                      topic, new MongoSinkTopicConfig(topic, originals));
+                if (!topicSinkConnectorConfigMap.containsKey(topic)) {
+                    try {
+                        if (RegexUtils.matches(topicRegex, topic, regexTimeoutDuration)) {
+                            topicSinkConnectorConfigMap.put(
+                                topic, new MongoSinkTopicConfig(topic, originals));
+                        }
+                    } catch (TimeoutException e) {
+                      String message = format(
+                          TOPIC_OVERRIDE_REGEX_TIMEOUT_ERROR_MESSAGE, regexTimeoutDuration,
+                          TOPIC_OVERRIDE_PREFIX, TOPICS_REGEX_CONFIG);
+                      throw new ConfigException(message);
+                    } catch (InterruptedException e) {
+                      Thread.currentThread().interrupt();
+                      String message = format(
+                          TOPIC_OVERRIDE_REGEX_ERROR_MESSAGE, e.getMessage(),
+                          TOPIC_OVERRIDE_PREFIX, TOPICS_REGEX_CONFIG);
+                      throw new ConfigException(message);
+                    } catch (ExecutionException e) {
+                      String message = format(
+                          TOPIC_OVERRIDE_REGEX_ERROR_MESSAGE, e.getMessage(),
+                          TOPIC_OVERRIDE_PREFIX, TOPICS_REGEX_CONFIG);
+                      throw new ConfigException(message);
+                    }
                 }
               });
     }
@@ -183,6 +224,10 @@ public class MongoSinkConfig extends AbstractConfig {
 
   public Map<String, String> getOriginals() {
     return originals;
+  }
+
+  public long getRegexTimeoutMs() {
+    return getLong(REGEX_TIMEOUT_MS);
   }
 
   public MongoSinkTopicConfig getMongoSinkTopicConfig(final String topic) {
@@ -282,6 +327,7 @@ public class MongoSinkConfig extends AbstractConfig {
         Width.MEDIUM,
         TOPICS_REGEX_DISPLAY);
 
+
     configDef.define(
         CONNECTION_URI_CONFIG,
         Type.PASSWORD,
@@ -310,6 +356,18 @@ public class MongoSinkConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         TOPIC_OVERRIDE_DISPLAY);
+
+    configDef.define(
+      REGEX_TIMEOUT_MS,
+      ConfigDef.Type.LONG,
+      REGEX_TIMEOUT_MS_DEFAULT,
+      ConfigDef.Range.atLeast(1),
+      ConfigDef.Importance.LOW,
+      REGEX_TIMEOUT_MS_DOC,
+      group,
+      ++orderInGroup,
+      ConfigDef.Width.SHORT,
+      REGEX_TIMEOUT_MS_DISPLAY);
 
     configDef.defineInternal(PROVIDER_CONFIG, Type.STRING, "", Importance.LOW);
 

--- a/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
@@ -244,6 +244,6 @@ final class StartedMongoSinkTask implements AutoCloseable {
   }
 
   private static void log(final Collection<SinkRecord> records, final RuntimeException e) {
-    LOGGER.error("Failed to put into the sink the following records: {}", records, e);
+    LOGGER.error("Failed to put {} records into the sink", records.size(), e);
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/ChangeStreamHandler.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/ChangeStreamHandler.java
@@ -64,10 +64,7 @@ public final class ChangeStreamHandler extends CdcHandler {
     BsonDocument changeStreamDocument = doc.getValueDoc().orElseGet(BsonDocument::new);
 
     if (!changeStreamDocument.containsKey(OPERATION_TYPE)) {
-      throw new DataException(
-          format(
-              "Error: `%s` field is doc is missing. %s",
-              OPERATION_TYPE, changeStreamDocument.toJson()));
+      throw new DataException(format("Error: `%s` field in doc is missing", OPERATION_TYPE));
     } else if (!changeStreamDocument.get(OPERATION_TYPE).isString()) {
       throw new DataException("Error: Unexpected CDC operation type, should be a string");
     }
@@ -76,9 +73,6 @@ public final class ChangeStreamHandler extends CdcHandler {
         OperationType.fromString(changeStreamDocument.get(OPERATION_TYPE).asString().getValue());
 
     LOGGER.debug("Creating operation handler for: {}", operationType);
-    if (LOGGER.isTraceEnabled()) {
-      LOGGER.trace("ChangeStream document {}", changeStreamDocument.toJson());
-    }
 
     if (OPERATIONS.containsKey(operationType)) {
       return Optional.of(OPERATIONS.get(operationType).perform(doc));

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/OperationHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/OperationHelper.java
@@ -40,7 +40,7 @@ final class OperationHelper {
   private static final String TRUNCATED_ARRAYS = "truncatedArrays";
   private static final String DISAMBIGUATED_PATHS = "disambiguatedPaths";
   private static final Set<String> UPDATE_DESCRIPTION_FIELDS =
-      new HashSet<>(asList(UPDATED_FIELDS, REMOVED_FIELDS, TRUNCATED_ARRAYS, DISAMBIGUATED_PATHS));
+          new HashSet<>(asList(UPDATED_FIELDS, REMOVED_FIELDS, TRUNCATED_ARRAYS, DISAMBIGUATED_PATHS));
 
   private static final String SET = "$set";
   private static final String UNSET = "$unset";
@@ -48,13 +48,12 @@ final class OperationHelper {
 
   static BsonDocument getDocumentKey(final BsonDocument changeStreamDocument) {
     if (!changeStreamDocument.containsKey(DOCUMENT_KEY)) {
-      throw new DataException(
-          format("Missing %s field: %s", DOCUMENT_KEY, changeStreamDocument.toJson()));
+      throw new DataException(format("Missing %s field", DOCUMENT_KEY));
     } else if (!changeStreamDocument.get(DOCUMENT_KEY).isDocument()) {
       throw new DataException(
-          format(
-              "Unexpected %s field type, expecting a document but found `%s`: %s",
-              DOCUMENT_KEY, changeStreamDocument.get(DOCUMENT_KEY), changeStreamDocument.toJson()));
+              format(
+                      "Unexpected %s field type, expecting a document but found `%s`",
+                      DOCUMENT_KEY, changeStreamDocument.get(DOCUMENT_KEY)));
     }
 
     return changeStreamDocument.getDocument(DOCUMENT_KEY);
@@ -66,15 +65,12 @@ final class OperationHelper {
 
   static BsonDocument getFullDocument(final BsonDocument changeStreamDocument) {
     if (!changeStreamDocument.containsKey(FULL_DOCUMENT)) {
-      throw new DataException(
-          format("Missing %s field: %s", FULL_DOCUMENT, changeStreamDocument.toJson()));
+      throw new DataException(format("Missing %s field", FULL_DOCUMENT));
     } else if (!changeStreamDocument.get(FULL_DOCUMENT).isDocument()) {
       throw new DataException(
-          format(
-              "Unexpected %s field type, expecting a document but found `%s`: %s",
-              FULL_DOCUMENT,
-              changeStreamDocument.get(FULL_DOCUMENT),
-              changeStreamDocument.toJson()));
+              format(
+                      "Unexpected %s field type, expecting a document but found `%s`",
+                      FULL_DOCUMENT, changeStreamDocument.get(FULL_DOCUMENT)));
     }
 
     return changeStreamDocument.getDocument(FULL_DOCUMENT);
@@ -82,15 +78,12 @@ final class OperationHelper {
 
   static BsonDocument getUpdateDocument(final BsonDocument changeStreamDocument) {
     if (!changeStreamDocument.containsKey(UPDATE_DESCRIPTION)) {
-      throw new DataException(
-          format("Missing %s field: %s", UPDATE_DESCRIPTION, changeStreamDocument.toJson()));
+      throw new DataException(format("Missing %s field", UPDATE_DESCRIPTION));
     } else if (!changeStreamDocument.get(UPDATE_DESCRIPTION).isDocument()) {
       throw new DataException(
-          format(
-              "Unexpected %s field type, expected a document found `%s`: %s",
-              UPDATE_DESCRIPTION,
-              changeStreamDocument.get(UPDATE_DESCRIPTION),
-              changeStreamDocument.toJson()));
+              format(
+                      "Unexpected %s field type, expected a document found `%s`",
+                      UPDATE_DESCRIPTION, changeStreamDocument.get(UPDATE_DESCRIPTION)));
     }
 
     BsonDocument updateDescription = changeStreamDocument.getDocument(UPDATE_DESCRIPTION);
@@ -98,53 +91,47 @@ final class OperationHelper {
     updateDescriptionFields.removeAll(UPDATE_DESCRIPTION_FIELDS);
     if (!updateDescriptionFields.isEmpty()) {
       throw new DataException(
-          format(
-              "Warning unexpected field(s) in %s %s. %s. Cannot process due to risk of data loss.",
-              UPDATE_DESCRIPTION, updateDescriptionFields, updateDescription.toJson()));
+              format(
+                      "Warning unexpected field(s) in %s %s. Cannot process due to risk of data loss.",
+                      UPDATE_DESCRIPTION, updateDescriptionFields));
     }
 
     if (!updateDescription.containsKey(UPDATED_FIELDS)) {
-      throw new DataException(
-          format(
-              "Missing %s.%s field: %s",
-              UPDATE_DESCRIPTION, UPDATED_FIELDS, updateDescription.toJson()));
+      throw new DataException(format("Missing %s.%s field", UPDATE_DESCRIPTION, UPDATED_FIELDS));
     } else if (!updateDescription.get(UPDATED_FIELDS).isDocument()) {
       throw new DataException(
-          format(
-              "Unexpected %s field type, expected a document but found `%s`: %s",
-              UPDATE_DESCRIPTION, updateDescription, updateDescription.toJson()));
+              format(
+                      "Unexpected %s field type, expected a document but found `%s`",
+                      UPDATE_DESCRIPTION, updateDescription));
     }
 
     if (!updateDescription.containsKey(REMOVED_FIELDS)) {
-      throw new DataException(
-          format(
-              "Missing %s.%s field: %s",
-              UPDATE_DESCRIPTION, REMOVED_FIELDS, updateDescription.toJson()));
+      throw new DataException(format("Missing %s.%s field", UPDATE_DESCRIPTION, REMOVED_FIELDS));
     } else if (!updateDescription.get(REMOVED_FIELDS).isArray()) {
       throw new DataException(
-          format(
-              "Unexpected %s field type, expected an array but found `%s`: %s",
-              REMOVED_FIELDS, updateDescription.get(REMOVED_FIELDS), updateDescription.toJson()));
+              format(
+                      "Unexpected %s field type, expected an array but found `%s`",
+                      REMOVED_FIELDS, updateDescription.get(REMOVED_FIELDS)));
     }
 
     if (updateDescription.containsKey(TRUNCATED_ARRAYS)
-        && !updateDescription.get(TRUNCATED_ARRAYS).isArray()) {
+            && !updateDescription.get(TRUNCATED_ARRAYS).isArray()) {
       throw new DataException(
-          format(
-              "Unexpected %s field type, expected an array but found `%s`: %s",
-              TRUNCATED_ARRAYS,
-              updateDescription.get(TRUNCATED_ARRAYS),
-              updateDescription.toJson()));
+              format(
+                      "Unexpected %s field type, expected an array but found `%s`: %s",
+                      TRUNCATED_ARRAYS,
+                      updateDescription.get(TRUNCATED_ARRAYS),
+                      updateDescription.toJson()));
     }
 
     if (updateDescription.containsKey(DISAMBIGUATED_PATHS)
-        && !updateDescription.get(DISAMBIGUATED_PATHS).isDocument()) {
+            && !updateDescription.get(DISAMBIGUATED_PATHS).isDocument()) {
       throw new DataException(
-          format(
-              "Unexpected %s field type, expected an array but found `%s`: %s",
-              DISAMBIGUATED_PATHS,
-              updateDescription.get(DISAMBIGUATED_PATHS),
-              updateDescription.toJson()));
+              format(
+                      "Unexpected %s field type, expected an array but found `%s`: %s",
+                      DISAMBIGUATED_PATHS,
+                      updateDescription.get(DISAMBIGUATED_PATHS),
+                      updateDescription.toJson()));
     }
 
     BsonDocument updatedFields = updateDescription.getDocument(UPDATED_FIELDS);
@@ -153,9 +140,9 @@ final class OperationHelper {
     for (final BsonValue removedField : removedFields) {
       if (!removedField.isString()) {
         throw new DataException(
-            format(
-                "Unexpected value type in %s, expected a string but found `%s`: %s",
-                REMOVED_FIELDS, removedField, updateDescription.toJson()));
+                format(
+                        "Unexpected value type in %s, expected an string but found `%s`",
+                        REMOVED_FIELDS, removedField));
       }
       unsetDocument.append(removedField.asString().getValue(), EMPTY_STRING);
     }

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/Update.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/Update.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import org.bson.BsonDocument;
 
 import com.mongodb.client.model.ReplaceOneModel;
+import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.UpdateOneModel;
 import com.mongodb.client.model.WriteModel;
 
@@ -50,7 +51,8 @@ public class Update implements CdcOperation {
     BsonDocument documentKey = getDocumentKey(changeStreamDocument);
     if (hasFullDocument(changeStreamDocument)) {
       LOGGER.debug("The full Document available, creating a replace operation.");
-      return new ReplaceOneModel<>(documentKey, getFullDocument(changeStreamDocument));
+      return new ReplaceOneModel<>(
+          documentKey, getFullDocument(changeStreamDocument), new ReplaceOptions().upsert(true));
     }
 
     LOGGER.debug("No full document field available, creating update operation.");

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/qlik/rdbms/RdbmsHandler.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/qlik/rdbms/RdbmsHandler.java
@@ -17,7 +17,6 @@
 package com.mongodb.kafka.connect.sink.cdc.qlik.rdbms;
 
 import static com.mongodb.kafka.connect.sink.cdc.qlik.rdbms.operations.OperationHelper.DEFAULT_OPERATIONS;
-import static java.lang.String.format;
 
 import java.util.Map;
 import java.util.Optional;
@@ -71,12 +70,7 @@ public class RdbmsHandler extends QlikCdcHandler {
     OperationType operationType = OperationHelper.getOperationType(valueDocument);
     CdcOperation cdcOperation =
         getCdcOperation(operationType)
-            .orElseThrow(
-                () ->
-                    new DataException(
-                        format(
-                            "Unable to determine the CDC operation from: %s",
-                            valueDocument.toJson())));
+            .orElseThrow(() -> new DataException("Unable to determine the CDC operation"));
 
     return Optional.ofNullable(cdcOperation.perform(new SinkDocument(keyDocument, valueDocument)));
   }

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/qlik/rdbms/operations/OperationHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/qlik/rdbms/operations/OperationHelper.java
@@ -83,8 +83,7 @@ public final class OperationHelper {
     }
 
     if (!operation.isString()) {
-      throw new DataException(
-          format("Error: Could not determine the CDC operation type. %s", valueDocument.toJson()));
+      throw new DataException("Error: Could not determine the CDC operation type.");
     }
 
     return OperationType.fromString(operation.asString().getValue());
@@ -107,9 +106,7 @@ public final class OperationHelper {
                 });
     if (filter.isEmpty()) {
       throw new DataException(
-          format(
-              "Error: Value Document does not contain the expected data, cannot create filter: %s.",
-              valueDocument.toJson()));
+          "Error: Value Document does not contain the expected data, cannot create filter.");
     }
     return filter;
   }
@@ -128,9 +125,7 @@ public final class OperationHelper {
                 });
     if (filter.isEmpty()) {
       throw new DataException(
-          format(
-              "Error: Value Document does not contain the expected data, cannot create filter: %s.",
-              valueDocument.toJson()));
+          "Error: Value Document does not contain the expected data, cannot create filter.");
     }
     return filter;
   }
@@ -157,9 +152,7 @@ public final class OperationHelper {
 
     if (afterDocument.isEmpty()) {
       throw new DataException(
-          format(
-              "Error: Value Document does not contain the expected data, cannot create filter: %s.",
-              valueDocument.toJson()));
+          "Error: Value Document does not contain the expected data, cannot create filter.");
     }
 
     BsonDocument updates = new BsonDocument();
@@ -205,9 +198,7 @@ public final class OperationHelper {
 
       if (!fieldValue.isDocument()) {
         throw new DataException(
-            format(
-                "Error: Value document contains a '%s' that is not a document: %s",
-                fieldName, original));
+            format("Error: Value document contains a '%s' that is not a document", fieldName));
       }
       return fieldValue.asDocument();
     }

--- a/src/main/java/com/mongodb/kafka/connect/sink/converter/LazyBsonDocument.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/converter/LazyBsonDocument.java
@@ -161,8 +161,9 @@ public class LazyBsonDocument extends BsonDocument {
           } catch (Exception e) {
             throw new DataException(
                 format(
-                    "Could not convert key %s into a BsonDocument.",
-                    unambiguousToString(record.key())),
+                    "Could not convert key in topic:%s at partition:%s offset:%s into a "
+                        + "BsonDocument",
+                    record.topic(), record.kafkaPartition(), record.kafkaOffset()),
                 e);
           }
           break;
@@ -172,8 +173,9 @@ public class LazyBsonDocument extends BsonDocument {
           } catch (Exception e) {
             throw new DataException(
                 format(
-                    "Could not convert value %s into a BsonDocument.",
-                    unambiguousToString(record.value())),
+                    "Could not convert value in topic:%s at partition:%s offset:%s into a "
+                        + "BsonDocument.",
+                    record.topic(), record.kafkaPartition(), record.kafkaOffset()),
                 e);
           }
           break;

--- a/src/main/java/com/mongodb/kafka/connect/sink/converter/SinkConverter.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/converter/SinkConverter.java
@@ -39,7 +39,11 @@ public class SinkConverter {
   private static final RecordConverter BYTE_ARRAY_RECORD_CONVERTER = new ByteArrayRecordConverter();
 
   public SinkDocument convert(final SinkRecord record) {
-    LOGGER.debug("record: {}", record);
+    LOGGER.debug(
+        "record in topic:{} at partition:{}, offset:{}",
+        record.topic(),
+        record.kafkaPartition(),
+        record.kafkaOffset());
 
     BsonDocument keyDoc = null;
     if (record.key() != null) {

--- a/src/main/java/com/mongodb/kafka/connect/sink/namespace/mapping/FieldPathNamespaceMapper.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/namespace/mapping/FieldPathNamespaceMapper.java
@@ -133,22 +133,25 @@ public class FieldPathNamespaceMapper implements NamespaceMapper {
           optionalData.orElseThrow(
               () ->
                   new DataException(
-                      format("Invalid %s document: %s", isKey ? "key" : "value", sinkRecord)));
+                      format(
+                          "Invalid %s document in topic:%s at partition:%s offset:%s",
+                          isKey ? "key" : "value",
+                          sinkRecord.topic(),
+                          sinkRecord.kafkaPartition(),
+                          sinkRecord.kafkaOffset())));
 
       Optional<BsonValue> optionalFieldValue = fieldLookup(path, data);
       if (continueProcessing(optionalFieldValue.isPresent())) {
         BsonValue fieldValue =
             optionalFieldValue.orElseThrow(
-                () ->
-                    new DataException(
-                        format("Missing document path '%s': %s", path, data.toJson())));
+                () -> new DataException(format("Missing document path '%s'", path)));
 
         if (continueProcessing(fieldValue.isString())) {
           if (!fieldValue.isString()) {
             throw new DataException(
                 format(
-                    "Invalid type for %s field path '%s', expected a String: %s",
-                    fieldValue.getBsonType(), path, data.toJson()));
+                    "Invalid type for %s field path '%s', expected a String",
+                    fieldValue.getBsonType(), path));
           }
 
           return fieldValue.asString().getValue();

--- a/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyHelper.java
@@ -56,7 +56,7 @@ public final class WriteModelStrategyHelper {
       return config
           .getDeleteWriteModelStrategy()
           .map(s -> s.createWriteModel(sinkDocument))
-          .orElseThrow(() -> new DataException("Could not create write model"));
+          .orElse(null);
     } catch (Exception e) {
       throw new DataException("Could not create write model", e);
     }

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoCopyDataManager.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoCopyDataManager.java
@@ -17,6 +17,7 @@ package com.mongodb.kafka.connect.source;
 
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COLLECTION_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.DATABASE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.REGEX_TIMEOUT_MS;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
@@ -30,8 +31,9 @@ import java.util.Optional;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import org.apache.kafka.connect.errors.ConnectException;
@@ -44,6 +46,7 @@ import org.bson.BsonType;
 import org.bson.RawBsonDocument;
 import org.bson.conversions.Bson;
 
+import com.github.jcustenborder.kafka.connect.utils.RegexUtils;
 import com.mongodb.MongoNamespace;
 import com.mongodb.client.MongoClient;
 
@@ -176,9 +179,22 @@ class MongoCopyDataManager implements AutoCloseable {
     }
 
     if (!namespacesRegex.isEmpty()) {
-      Predicate<String> predicate = Pattern.compile(namespacesRegex).asPredicate();
+      Pattern pattern = Pattern.compile(namespacesRegex);
+      long regexTimeout = sourceConfig.getLong(REGEX_TIMEOUT_MS);
       namespaces =
-          namespaces.stream().filter(n -> predicate.test(n.getFullName())).collect(toList());
+          namespaces.stream().filter(n -> {
+            try {
+              return RegexUtils.find(pattern, n.getFullName(), regexTimeout);
+            } catch (TimeoutException e) {
+              throw new ConnectException(
+                  "Regex replacement operation timed out after " + regexTimeout + "ms", e);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+              throw new ConnectException("Thread was interrupted during regex replacement", e);
+            } catch (ExecutionException e) {
+              throw new ConnectException("Error during regex replacement", e);
+            }
+          }).collect(toList());
     }
 
     return namespaces;

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -293,7 +293,7 @@ public class MongoSourceConfig extends AbstractConfig {
           PUBLISH_FULL_DOCUMENT_ONLY_TOMBSTONE_ON_DELETE_DEFAULT);
 
   public static final String DOCUMENT_KEY_AS_KEY_CONFIG = "change.stream.document.key.as.key";
-  private static final boolean DOCUMENT_KEY_AS_KEY_DEFAULT = true;
+  private static final boolean DOCUMENT_KEY_AS_KEY_DEFAULT = false;
   private static final String DOCUMENT_KEY_AS_KEY_DISPLAY =
       "Use the `documentKey` for the source record key";
   private static final String DOCUMENT_KEY_AS_KEY_DOC =

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -549,6 +549,16 @@ public class MongoSourceConfig extends AbstractConfig {
   public static final String OVERRIDE_ERRORS_TOLERANCE_DOC =
       "Use this property if you would like to configure the connector's error handling behavior differently from the Connect framework's.";
 
+  public static final String REMOVE_FIELD_ON_SCHEMA_MISMATCH_CONFIG = "remove.field.on.schema.mismatch";
+  public static final boolean REMOVE_FIELD_ON_SCHEMA_MISMATCH_DEFAULT = true;
+  private static final String REMOVE_FIELD_ON_SCHEMA_MISMATCH_DOC =
+      "If true, remove fields from the document that are not present in the schema. "
+          + "Otherwise, throw an error or send the documents to the DLQ depending on the value of "
+          + ERRORS_TOLERANCE_CONFIG
+          + " being set to ALL or NONE respectively.";
+  private static final String REMOVE_FIELD_ON_SCHEMA_MISMATCH_DISPLAY =
+      "Remove Field on Schema Mismatch";
+
   public static final String ERRORS_LOG_ENABLE_CONFIG = "errors.log.enable";
   public static final String ERRORS_LOG_ENABLE_DISPLAY = "Log Errors";
   public static final boolean ERRORS_LOG_ENABLE_DEFAULT = false;
@@ -1486,6 +1496,18 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.SHORT,
         ERRORS_TOLERANCE_DISPLAY);
+
+    configDef.define(
+        REMOVE_FIELD_ON_SCHEMA_MISMATCH_CONFIG,
+        Type.BOOLEAN,
+        REMOVE_FIELD_ON_SCHEMA_MISMATCH_DEFAULT,
+        Importance.MEDIUM,
+        REMOVE_FIELD_ON_SCHEMA_MISMATCH_DOC,
+        group,
+        ++orderInGroup,
+        Width.SHORT,
+        REMOVE_FIELD_ON_SCHEMA_MISMATCH_DISPLAY
+    );
 
     configDef.define(
         ERRORS_LOG_ENABLE_CONFIG,

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -463,6 +463,14 @@ public class MongoSourceConfig extends AbstractConfig {
           + "\nIt is an equivalent replacement for the deprecated 'copy.existing.namespace.regex'.";
   static final String STARTUP_MODE_COPY_EXISTING_NAMESPACE_REGEX_DEFAULT = EMPTY_STRING;
 
+  public static final String REGEX_TIMEOUT_MS = "regex.timeout.ms";
+  public static final long REGEX_TIMEOUT_MS_DEFAULT = 100L;
+  private static final String REGEX_TIMEOUT_MS_DOC =
+      "Timeout in milliseconds for any regex operation. This controls how long the connector will "
+          + "wait for regex pattern compilation, matching, replacement, or any other regex-related "
+          + "operation to complete before timing out.";
+  private static final String REGEX_TIMEOUT_MS_DISPLAY = "Regex Timeout (ms)";
+
   static final String STARTUP_MODE_COPY_EXISTING_ALLOW_DISK_USE_CONFIG =
       "startup.mode.copy.existing.allow.disk.use";
   private static final String STARTUP_MODE_COPY_EXISTING_ALLOW_DISK_USE_DISPLAY =
@@ -1389,6 +1397,18 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         STARTUP_MODE_COPY_EXISTING_NAMESPACE_REGEX_DISPLAY);
+
+    configDef.define(
+        REGEX_TIMEOUT_MS,
+        ConfigDef.Type.LONG,
+        REGEX_TIMEOUT_MS_DEFAULT,
+        ConfigDef.Range.atLeast(1),
+        ConfigDef.Importance.LOW,
+        REGEX_TIMEOUT_MS_DOC,
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.SHORT,
+        REGEX_TIMEOUT_MS_DISPLAY);
 
     configDef.define(
         STARTUP_MODE_COPY_EXISTING_ALLOW_DISK_USE_CONFIG,

--- a/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
@@ -56,6 +56,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.utils.Time;
@@ -63,6 +65,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTaskContext;
 
@@ -75,6 +78,7 @@ import org.bson.RawBsonDocument;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoException;
+import com.mongodb.MongoQueryException;
 import com.mongodb.client.ChangeStreamIterable;
 import com.mongodb.client.MongoChangeStreamCursor;
 import com.mongodb.client.MongoClient;
@@ -235,8 +239,7 @@ final class StartedMongoSourceTask implements AutoCloseable {
 
       String topicName = topicMapper.getTopic(changeStreamDocument);
       if (topicName.isEmpty()) {
-        LOGGER.warn(
-            "No topic set. Could not publish the message: {}", changeStreamDocument.toJson());
+        LOGGER.warn("No topic set. Could not publish the message.");
       } else {
 
         Optional<BsonDocument> valueDocument = Optional.empty();
@@ -255,7 +258,7 @@ final class StartedMongoSourceTask implements AutoCloseable {
 
         if (valueDocument.isPresent() || isTombstoneEvent) {
           BsonDocument valueDoc = valueDocument.orElse(new BsonDocument());
-          LOGGER.trace("Adding {} to {}: {}", valueDoc, topicName, sourceOffset);
+          LOGGER.trace("Adding document (hash) {} to {}: {}", valueDoc.hashCode(), topicName, sourceOffset);
 
           if (valueDoc instanceof RawBsonDocument) {
             int sizeBytes = ((RawBsonDocument) valueDoc).getByteBuffer().limit();
@@ -322,13 +325,7 @@ final class StartedMongoSourceTask implements AutoCloseable {
               valueSchemaAndValue.schema(),
               valueSchemaAndValue.value()));
     } catch (Exception e) {
-      Supplier<String> errorMessage =
-          () ->
-              format(
-                  "%s : Exception creating Source record for: Key=%s Value=%s",
-                  e.getMessage(),
-                  keyDocument == null ? "" : keyDocument.toJson(),
-                  valueDocument == null ? "" : valueDocument.toJson());
+      Supplier<String> errorMessage = () -> "Exception creating Source record";
       if (sourceConfig.logErrors()) {
         LOGGER.error(errorMessage.get(), e);
       }
@@ -336,15 +333,26 @@ final class StartedMongoSourceTask implements AutoCloseable {
         if (sourceConfig.getDlqTopic().isEmpty()) {
           return Optional.empty();
         }
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("error_message", e.getMessage() != null ? e.getMessage() : "Unknown error occurred");
+        String fullStackTrace = Stream.of(e.getStackTrace())
+                .map(StackTraceElement::toString)
+                .collect(Collectors.joining(System.lineSeparator()));
+
+        String truncatedStackTrace = fullStackTrace.substring(0, Math.min(400, fullStackTrace.length()));
+        headers.addString("truncated_stacktrace", truncatedStackTrace);
         return Optional.of(
             new SourceRecord(
                 partitionMap,
                 sourceOffset,
                 sourceConfig.getDlqTopic(),
+                null,
                 Schema.STRING_SCHEMA,
                 keyDocument == null ? "" : keyDocument.toJson(),
                 Schema.STRING_SCHEMA,
-                valueDocument == null ? "" : valueDocument.toJson()));
+                valueDocument == null ? "" : valueDocument.toJson(),
+                null,
+                headers));
       }
       throw new DataException(errorMessage.get(), e);
     }
@@ -496,6 +504,8 @@ final class StartedMongoSourceTask implements AutoCloseable {
         if (changeStreamNotValid(e)) {
           throw new ConnectException(
               "ResumeToken not found. Cannot create a change stream cursor", e);
+        } else {
+          throw new ConnectException("Failed to resume change stream", e);
         }
       }
       return null;
@@ -620,10 +630,11 @@ final class StartedMongoSourceTask implements AutoCloseable {
                 "An exception occurred when trying to get the next item from the Change Stream", e);
           }
         } else {
-          throw new ConnectException(
-              "An exception occurred when trying to get the next item from the Change Stream: "
-                  + e.getMessage(),
-              e);
+          LOGGER.error(
+              "An exception occurred when trying to get the next item from the Change Stream", e);
+          if (e instanceof MongoQueryException && ((MongoQueryException) e).getErrorCode() == 286) {
+            throw new ConnectException("Failed to resume change stream", e);
+          }
         }
       }
     } catch (Exception e) {

--- a/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
@@ -27,6 +27,7 @@ import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_AWAIT_TIME
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_MAX_BATCH_SIZE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.PUBLISH_FULL_DOCUMENT_ONLY_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.PUBLISH_FULL_DOCUMENT_ONLY_TOMBSTONE_ON_DELETE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.REMOVE_FIELD_ON_SCHEMA_MISMATCH_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.StartupConfig.StartupMode.COPY_EXISTING;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.StartupConfig.StartupMode.TIMESTAMP;
 import static com.mongodb.kafka.connect.source.MongoSourceTask.COPY_KEY;
@@ -313,6 +314,9 @@ final class StartedMongoSourceTask implements AutoCloseable {
       @Nullable final BsonDocument valueDocument) {
 
     try {
+      if (!sourceConfig.getBoolean(REMOVE_FIELD_ON_SCHEMA_MISMATCH_CONFIG)) {
+        valueSchemaAndValueProducer.checkForExtraFields(valueDocument);
+      }
       SchemaAndValue keySchemaAndValue = keySchemaAndValueProducer.get(keyDocument);
       SchemaAndValue valueSchemaAndValue = valueSchemaAndValueProducer.get(valueDocument);
       return Optional.of(

--- a/src/main/java/com/mongodb/kafka/connect/source/producer/AvroSchemaAndValueProducer.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/producer/AvroSchemaAndValueProducer.java
@@ -38,4 +38,9 @@ final class AvroSchemaAndValueProducer implements SchemaAndValueProducer {
   public SchemaAndValue get(final BsonDocument changeStreamDocument) {
     return bsonValueToSchemaAndValue.toSchemaAndValue(schema, changeStreamDocument);
   }
+
+  @Override
+  public void checkForExtraFields(final BsonDocument changeStreamDocument) {
+    bsonValueToSchemaAndValue.checkForExtraFields(schema, changeStreamDocument);
+  }
 }

--- a/src/main/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducer.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducer.java
@@ -22,4 +22,7 @@ import org.bson.BsonDocument;
 
 public interface SchemaAndValueProducer {
   SchemaAndValue get(BsonDocument changeStreamDocument);
+  default void checkForExtraFields(final BsonDocument changeStreamDocument) {
+    // no-op
+  }
 }

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValue.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValue.java
@@ -310,7 +310,6 @@ public class BsonValueToSchemaAndValue {
   }
 
   private DataException missingFieldException(final Field field, final BsonDocument value) {
-    return new DataException(
-        format("Missing field '%s' in: '%s'", field.name(), value.toJson(jsonWriterSettings)));
+    return new DataException(format("Missing field '%s'", field.name()));
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValue.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValue.java
@@ -60,6 +60,7 @@ import org.bson.codecs.Codec;
 import org.bson.codecs.EncoderContext;
 import org.bson.io.BasicOutputBuffer;
 import org.bson.json.JsonWriterSettings;
+import org.bson.BsonArray;
 
 public class BsonValueToSchemaAndValue {
   private static final Codec<BsonValue> BSON_VALUE_CODEC = new BsonValueCodec();
@@ -287,6 +288,38 @@ public class BsonValueToSchemaAndValue {
     return new SchemaAndValue(schema, structValue);
   }
 
+  public void checkForExtraFields(final Schema schema, final BsonValue bsonValue) {
+    if (schema.isOptional() && bsonValue.isNull()) {
+      return;
+    }
+    if (schema.type() == Type.STRUCT && bsonValue.isDocument()) {
+      BsonDocument doc = bsonValue.asDocument();
+      doc.forEach(
+          (key, value) -> {
+            Field field = schema.field(key);
+            if (field == null) {
+              throw extraFieldException(key);
+            }
+            checkForExtraFields(field.schema(), value);
+          }
+      );
+    } else if (schema.type() == Type.ARRAY && bsonValue.isArray()) {
+      BsonArray array = bsonValue.asArray();
+      array.forEach(
+          value -> {
+            checkForExtraFields(schema.valueSchema(), value);
+          }
+      );
+    } else if (schema.type() == Type.MAP && bsonValue.isDocument()) {
+      BsonDocument doc = bsonValue.asDocument();
+      doc.forEach(
+          (key, value) -> {
+            checkForExtraFields(schema.valueSchema(), value);
+          }
+      );
+    }
+  }
+
   private SchemaAndValue booleanToSchemaAndValue(final Schema schema, final BsonValue bsonValue) {
     if (!bsonValue.isBoolean()) {
       throw unexpectedBsonValueType(Schema.Type.BOOLEAN, bsonValue);
@@ -311,5 +344,9 @@ public class BsonValueToSchemaAndValue {
 
   private DataException missingFieldException(final Field field, final BsonDocument value) {
     return new DataException(format("Missing field '%s'", field.name()));
+  }
+
+  private DataException extraFieldException(final String key) {
+    return new DataException(format("The field '%s' is not defined in the Schema.", key));
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/util/ConnectionValidator.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/ConnectionValidator.java
@@ -94,43 +94,57 @@ public final class ConnectionValidator {
             customCredentialProvider.getCustomCredential(connectorProperties.originals()));
       }
       setServerApi(mongoClientSettingsBuilder, config);
+      final MongoClientSettings mongoClientSettings;
+      try {
+        mongoClientSettings =
+            mongoClientSettingsBuilder
+                .applyToClusterSettings(
+                    b ->
+                        b.addClusterListener(
+                            new ClusterListener() {
+                              @Override
+                              public void clusterOpening(final ClusterOpeningEvent event) {}
 
-      MongoClientSettings mongoClientSettings =
-          mongoClientSettingsBuilder
-              .applyToClusterSettings(
-                  b ->
-                      b.addClusterListener(
-                          new ClusterListener() {
-                            @Override
-                            public void clusterOpening(final ClusterOpeningEvent event) {}
+                              @Override
+                              public void clusterClosed(final ClusterClosedEvent event) {}
 
-                            @Override
-                            public void clusterClosed(final ClusterClosedEvent event) {}
-
-                            @Override // Different database than has permissions for
-                            public void clusterDescriptionChanged(
-                                final ClusterDescriptionChangedEvent event) {
-                              ReadPreference readPreference =
-                                  connectionString.getReadPreference() != null
-                                      ? connectionString.getReadPreference()
-                                      : ReadPreference.primaryPreferred();
-                              if (!connected.get()
-                                  && event.getNewDescription().hasReadableServer(readPreference)) {
-                                connected.set(true);
-                                latch.countDown();
+                              @Override // Different database than has permissions for
+                              public void clusterDescriptionChanged(
+                                  final ClusterDescriptionChangedEvent event) {
+                                ReadPreference readPreference =
+                                    connectionString.getReadPreference() != null
+                                        ? connectionString.getReadPreference()
+                                        : ReadPreference.primaryPreferred();
+                                if (!connected.get()
+                                    && event
+                                        .getNewDescription()
+                                        .hasReadableServer(readPreference)) {
+                                  connected.set(true);
+                                  latch.countDown();
+                                }
                               }
-                            }
-                          }))
-              .applyToSslSettings(sslBuilder -> setupSsl(sslBuilder, connectorProperties))
-              .build();
+                            }))
+                .applyToSslSettings(sslBuilder -> setupSsl(sslBuilder, connectorProperties))
+                .build();
+      } catch (IllegalArgumentException exception) {
+        configValue.addErrorMessage(exception.getMessage());
+        return Optional.empty();
+      }
 
       long latchTimeout =
           mongoClientSettings.getSocketSettings().getConnectTimeout(TimeUnit.MILLISECONDS) + 500;
       MongoClient mongoClient = MongoClients.create(mongoClientSettings);
 
       try {
-        if (!latch.await(latchTimeout, TimeUnit.MILLISECONDS)) {
-          configValue.addErrorMessage("Unable to connect to the server.");
+        if (connectionString.isSrvProtocol()) {
+          if (!latch.await(latchTimeout, TimeUnit.MILLISECONDS)) {
+            configValue.addErrorMessage("Unable to connect to the server.");
+            mongoClient.close();
+          } else {
+            mongoClient.close();
+          }
+        } else {
+          configValue.addErrorMessage("Non-SRV protocol host is not supported");
           mongoClient.close();
         }
       } catch (InterruptedException e) {

--- a/src/main/java/com/mongodb/kafka/connect/util/ConnectionValidator.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/ConnectionValidator.java
@@ -136,17 +136,10 @@ public final class ConnectionValidator {
       MongoClient mongoClient = MongoClients.create(mongoClientSettings);
 
       try {
-        if (connectionString.isSrvProtocol()) {
           if (!latch.await(latchTimeout, TimeUnit.MILLISECONDS)) {
             configValue.addErrorMessage("Unable to connect to the server.");
             mongoClient.close();
-          } else {
-            mongoClient.close();
           }
-        } else {
-          configValue.addErrorMessage("Non-SRV protocol host is not supported");
-          mongoClient.close();
-        }
       } catch (InterruptedException e) {
         mongoClient.close();
         throw new ConnectException(e);

--- a/src/main/java/com/mongodb/kafka/connect/util/Validators.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/Validators.java
@@ -37,8 +37,14 @@ import org.apache.kafka.common.config.types.Password;
 import org.slf4j.Logger;
 
 import com.mongodb.kafka.connect.util.config.BsonTimestampParser;
+import org.slf4j.LoggerFactory;
 
 public final class Validators {
+
+  private static String redactedUrl = "[REDACTED URL]";
+  private static final Logger LOGGER = LoggerFactory.getLogger(Validators.class);
+  private static String connectionUriErrorMessage = "Connection string is invalid. Please enter " +
+          "the valid connection.host, connection.user and connection.password and try again.";
 
   public interface ValidatorWithOperators extends ConfigDef.Validator {
     default ValidatorWithOperators or(final ValidatorWithOperators other) {
@@ -161,8 +167,11 @@ public final class Validators {
         ((name, value) -> {
           try {
             consumer.accept((String) value);
+          } catch (IllegalArgumentException e){
+            LOGGER.error(e.getMessage());
+            throw new ConfigException(name, redactedUrl, connectionUriErrorMessage);
           } catch (Exception e) {
-            throw new ConfigException(name, value, e.getMessage());
+            throw new ConfigException(name, redactedUrl, e.getMessage());
           }
         }));
   }

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordDataTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordDataTest.java
@@ -70,6 +70,9 @@ class MongoProcessedSinkRecordDataTest {
       new SinkRecord(
           TEST_TOPIC, 0, Schema.STRING_SCHEMA, "{_id: 1}", Schema.STRING_SCHEMA, VALUE_JSON, 1);
 
+  private static final SinkRecord TOMBSTONE_SINK_RECORD =
+      new SinkRecord(TEST_TOPIC, 0, Schema.STRING_SCHEMA, "{_id: 1}", null, null, 1);
+
   private static final SinkRecord INVALID_SINK_RECORD =
       new SinkRecord(TEST_TOPIC, 0, Schema.INT32_SCHEMA, 1, Schema.INT32_SCHEMA, 1, 1);
 
@@ -104,6 +107,16 @@ class MongoProcessedSinkRecordDataTest {
 
     assertEquals(new MongoNamespace("myDB.myColl"), processedData.getNamespace());
     assertWriteModel(processedData);
+  }
+
+  @Test
+  @DisplayName("test default processing tombstone record")
+  void testDefaultProcessingTombstone() {
+    MongoProcessedSinkRecordData processedData =
+        new MongoProcessedSinkRecordData(TOMBSTONE_SINK_RECORD, createSinkConfig());
+
+    assertEquals(new MongoNamespace("myDB.topic"), processedData.getNamespace());
+    assertNull(processedData.getWriteModel());
   }
 
   @Test

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
@@ -301,6 +301,44 @@ class MongoSinkConfigTest {
   }
 
   @Test
+  @DisplayName("test topic regex with overrides avoids CWE-1333 ReDOS")
+  void testTopicRegexWithOverridesReDOS() {
+    String safeRegex = "(a+)+";
+    String unsafeRegex = "(a+)+b";
+    
+    // Create a string that will definitely cause a timeout with the unsafe regex,
+    // but not with the safe regex
+    // The string contains only 'a's but the unsafe regex requires a 'b' at the end
+    // This will cause catastrophic backtracking.
+    // The length of topic must be greater than 100000 to cause a timeout.
+    StringBuilder input = new StringBuilder();
+    for (int i = 0; i < 100000; i++) {
+      input.append("a");
+    }
+    String topicOverride = input.toString();
+
+    MongoSinkConfig cfg =
+        createSinkConfig(
+            format(
+                "{'%s': '%s', '%s': 'otherDB', '%s': 'coll2'}",
+                TOPICS_REGEX_CONFIG,
+                safeRegex,
+                createOverrideKey(topicOverride, DATABASE_CONFIG),
+                createOverrideKey(topicOverride, COLLECTION_CONFIG)));
+    assertPattern("(a+)+", cfg.getTopicRegex().orElse(EMPTY_PATTERN));
+    assertEquals("otherDB", cfg.getMongoSinkTopicConfig(topicOverride).getString(DATABASE_CONFIG));
+    assertEquals("coll2", cfg.getMongoSinkTopicConfig(topicOverride).getString(COLLECTION_CONFIG));
+    ConfigException exception = assertThrows(
+        ConfigException.class,
+        () ->
+            createSinkConfig(
+                format(
+                    "{'%s': '%s', '%s': 'made up'}",
+                    TOPICS_REGEX_CONFIG, unsafeRegex, createOverrideKey(topicOverride, KEY_PROJECTION_TYPE_CONFIG))));
+    assertTrue(exception.getMessage().contains("Regex match operation timed out after "));
+  }
+
+  @Test
   @DisplayName("test K/V projection with invalid projection type")
   void testProjectionWithInvalidProjectionTypes() {
     assertAll(

--- a/src/test/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/UpdateTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/UpdateTest.java
@@ -18,7 +18,6 @@ package com.mongodb.kafka.connect.sink.cdc.mongodb.operations;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -79,9 +78,9 @@ class UpdateTest {
         "filter expected to be of type BsonDocument");
     assertEquals(CHANGE_EVENT.getDocument("documentKey"), writeModel.getFilter());
     assertEquals(CHANGE_EVENT.getDocument("fullDocument"), writeModel.getReplacement());
-    assertFalse(
+    assertTrue(
         writeModel.getReplaceOptions().isUpsert(),
-        "update replacement expected not to be in upsert mode");
+        "update replacement expected to be in upsert mode");
   }
 
   @Test

--- a/src/test/java/com/mongodb/kafka/connect/source/MongoCopyDataManagerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/MongoCopyDataManagerTest.java
@@ -20,6 +20,7 @@ import static com.mongodb.kafka.connect.source.MongoSourceConfig.COLLECTION_CONF
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COPY_EXISTING_ALLOW_DISK_USE_DEFAULT;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.DATABASE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.PIPELINE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.REGEX_TIMEOUT_MS;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.STARTUP_MODE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.STARTUP_MODE_COPY_EXISTING_ALLOW_DISK_USE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.STARTUP_MODE_COPY_EXISTING_NAMESPACE_REGEX_CONFIG;
@@ -36,6 +37,8 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -48,10 +51,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -477,6 +482,52 @@ class MongoCopyDataManagerTest {
       sleep();
       copyExistingDataManager.poll();
     }
+  }
+
+  @Test
+  public void testRegexReplacementWithTimeout() {
+    StringBuilder input = new StringBuilder();
+    for (int i = 0; i < 10000; i++) {
+      input.append("a");
+    }
+    String inputString = input.toString();
+
+    Map<String, String> props = new HashMap<>();
+    props.put(STARTUP_MODE_CONFIG, StartupMode.COPY_EXISTING.propertyValue());
+    props.put(DATABASE_CONFIG, inputString);
+    props.put(COLLECTION_CONFIG, inputString);
+    props.put(STARTUP_MODE_COPY_EXISTING_NAMESPACE_REGEX_CONFIG, "(([a.]+)+)Z");
+    props.put(REGEX_TIMEOUT_MS, "100");
+    MongoSourceConfig sourceConfig = createSourceConfig(props);
+
+    ConnectException exception = assertThrows(ConnectException.class,
+        () -> new MongoCopyDataManager(sourceConfig, mongoClient));
+    assertInstanceOf(TimeoutException.class, exception.getCause());
+  }
+
+  @Test
+  public void testRegexReplacementWithInterruption() throws InterruptedException {
+    StringBuilder input = new StringBuilder();
+    for (int i = 0; i < 10000; i++) {
+      input.append("a");
+    }
+    String inputString = input.toString();
+
+    Map<String, String> props = new HashMap<>();
+    props.put(STARTUP_MODE_CONFIG, StartupMode.COPY_EXISTING.propertyValue());
+    props.put(DATABASE_CONFIG, inputString);
+    props.put(COLLECTION_CONFIG, inputString);
+    props.put(STARTUP_MODE_COPY_EXISTING_NAMESPACE_REGEX_CONFIG, "(([a.]+)+)Z");
+    MongoSourceConfig sourceConfig = createSourceConfig(props);
+
+    Thread copyDataManagerThread = new Thread(() -> {
+      ConnectException e = assertThrows(ConnectException.class, () -> new MongoCopyDataManager(sourceConfig, mongoClient));
+      assertInstanceOf(InterruptedException.class, e.getCause(), "Expected InterruptedException as cause");
+      assertTrue(Thread.currentThread().isInterrupted(), "Thread should be interrupted");
+    });
+    copyDataManagerThread.start();
+    copyDataManagerThread.interrupt();
+    copyDataManagerThread.join(2000);
   }
 
   private void sleep(final int millis) {

--- a/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
@@ -28,6 +28,8 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.math.BigDecimal;
 import java.util.Base64;
@@ -41,6 +43,8 @@ import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.DataException;
+import org.bson.BsonInt32;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -149,6 +153,92 @@ public class SchemaAndValueProducerTest {
         new AvroSchemaAndValueProducer(DEFAULT_AVRO_VALUE_SCHEMA, EXTENDED_JSON_WRITER_SETTINGS);
     assertSchemaAndValueEquals(
         expectedExtendedValue, extendedJsonValueProducer.get(CHANGE_STREAM_DOCUMENT));
+  }
+
+  @Test
+  @DisplayName("test extra fields not in schema")
+  void testExtraFieldsNotInSchema() {
+    String complexJsonSchema = "{"
+        + "\"type\": \"record\","
+        + "\"name\": \"ComplexRecord\","
+        + "\"fields\": ["
+        + "  {"
+        + "    \"name\": \"nestedDocument\","
+        + "    \"type\": {"
+        + "      \"type\": \"record\","
+        + "      \"name\": \"NestedDocument\","
+        + "      \"fields\": ["
+        + "        {\"name\": \"field1\", \"type\": \"string\"},"
+        + "        {\"name\": \"field2\", \"type\": \"int\"}"
+        + "      ]"
+        + "    }"
+        + "  },"
+        + "  {"
+        + "    \"name\": \"arrayWithDocuments\","
+        + "    \"type\": {"
+        + "      \"type\": \"array\","
+        + "      \"items\": {"
+        + "        \"type\": \"record\","
+        + "        \"name\": \"ArrayItem\","
+        + "        \"fields\": ["
+        + "          {\"name\": \"itemField1\", \"type\": \"string\"},"
+        + "          {\"name\": \"itemField2\", \"type\": \"boolean\"}"
+        + "        ]"
+        + "      }"
+        + "    }"
+        + "  }"
+        + "]"
+        + "}";
+
+    String complexJsonValue = "{\n" +
+        "  \"nestedDocument\": {\n" +
+        "    \"field1\": \"example string\",\n" +
+        "    \"field2\": 123\n" +
+        "  },\n" +
+        "  \"arrayWithDocuments\": [\n" +
+        "    {\n" +
+        "      \"itemField1\": \"item1\",\n" +
+        "      \"itemField2\": true\n" +
+        "    },\n" +
+        "    {\n" +
+        "      \"itemField1\": \"item2\",\n" +
+        "      \"itemField2\": false\n" +
+        "    }\n" +
+        "  ]\n" +
+        "}";
+
+    BsonDocument fullDocument = BsonDocument.parse(complexJsonValue);
+
+    SchemaAndValueProducer inferSchemaAndValueProducer =
+        new InferSchemaAndValueProducer(SIMPLE_JSON_WRITER_SETTINGS);
+    assertDoesNotThrow(
+        () -> inferSchemaAndValueProducer.checkForExtraFields(fullDocument));
+
+    SchemaAndValueProducer avroSchemaAndValueProducer =
+        new AvroSchemaAndValueProducer(complexJsonSchema, SIMPLE_JSON_WRITER_SETTINGS);
+    assertDoesNotThrow(
+        () -> avroSchemaAndValueProducer.checkForExtraFields(fullDocument));
+
+    fullDocument.get("arrayWithDocuments").asArray().get(1).asDocument().append("extraField", new BsonInt32(1));
+    assertThrows(
+        DataException.class,
+        () -> avroSchemaAndValueProducer.checkForExtraFields(fullDocument));
+    fullDocument.get("arrayWithDocuments").asArray().get(1).asDocument().remove("extraField");
+
+    fullDocument.get("nestedDocument").asDocument().append("extraField", new BsonInt32(1));
+    assertThrows(
+        DataException.class,
+        () -> avroSchemaAndValueProducer.checkForExtraFields(fullDocument));
+    fullDocument.get("nestedDocument").asDocument().remove("extraField");
+
+    fullDocument.append("extraField", new BsonInt32(1));
+    assertThrows(
+        DataException.class,
+        () -> avroSchemaAndValueProducer.checkForExtraFields(fullDocument));
+    fullDocument.remove("extraField");
+
+    assertDoesNotThrow(
+        () -> avroSchemaAndValueProducer.checkForExtraFields(fullDocument));
   }
 
   @Test


### PR DESCRIPTION
https://confluentinc.atlassian.net/issues/CC-35540
Upgraded the version of mongo-kafka to v1.16.x using release tag [r1.16.0](https://github.com/mongodb/mongo-kafka/releases/tag/r1.16.0)
Cherry picked the changes from v1.14.x into branch v1.16.x.

Upgrade checklist for MongoDB Atlas v1.16.x - https://confluentinc.atlassian.net/wiki/x/RYNNEQE