### PR TITLE
CC-35524 : Fix and Enable Integration tests for MongoDB Atlas connector

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -39,6 +39,7 @@ blocks:
             - pip install confluent-release-tools -q
             - . sem-pint -c
             - ./gradlew test
+            - ./gradlew integrationTest
             - . cve-scan
             - . cache-maven store
       epilogue:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,6 +64,7 @@ extra.apply {
     set("confluentVersion", "6.0.1")
     set("scalaVersion", "2.13")
     set("curatorVersion", "2.9.0")
+    set("testcontainersVersion", "1.21.3")
 }
 
 val mongoDependencies: Configuration by configurations.creating
@@ -103,6 +104,10 @@ dependencies {
     testImplementation(group = "org.scala-lang", name = "scala-library")
     testImplementation(group = "org.apache.kafka", name = "kafka_${project.extra["scalaVersion"]}")
     testImplementation(group = "org.apache.kafka", name = "kafka_${project.extra["scalaVersion"]}", classifier = "test")
+    testImplementation(platform("org.testcontainers:testcontainers-bom:${project.extra["testcontainersVersion"]}"))
+    testImplementation("org.testcontainers:testcontainers")
+    testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("org.testcontainers:mongodb")
 }
 
 tasks.withType<JavaCompile> {

--- a/src/integrationTest/java/com/mongodb/kafka/connect/ConnectorValidationIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/ConnectorValidationIntegrationTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeAll;
 
 import org.bson.BsonDocument;
 import org.bson.Document;
@@ -55,6 +56,7 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
 
+import com.mongodb.kafka.connect.mongodb.MongoDBHelper;
 import com.mongodb.kafka.connect.sink.MongoSinkConfig;
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
 import com.mongodb.kafka.connect.source.MongoSourceConfig;
@@ -73,11 +75,17 @@ public final class ConnectorValidationIntegrationTest {
   private static final String CUSTOM_COLLECTION = "customCollection";
   private static MongoClient mongoClient;
 
+  @BeforeAll
+  static void setUp() {
+    MongoDBHelper.startMongoContainer();
+  }
+
   @AfterAll
   static void done() {
     if (mongoClient != null) {
       mongoClient.close();
     }
+    MongoDBHelper.closeMongoDbContainer();
   }
 
   @AfterEach

--- a/src/integrationTest/java/com/mongodb/kafka/connect/mongodb/MongoDBHelper.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/mongodb/MongoDBHelper.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.mongodb.MongoDBAtlasLocalContainer;
 
 import com.mongodb.ConnectionString;
 import com.mongodb.client.MongoClient;
@@ -33,6 +34,15 @@ public class MongoDBHelper
   private static final String DEFAULT_URI = "mongodb://localhost:27017";
   private static final String URI_SYSTEM_PROPERTY_NAME = "org.mongodb.test.uri";
   private static final String DEFAULT_DATABASE_NAME = "MongoKafkaTest";
+  private static final String MONGO_USERNAME = "test_username";
+  private static final String MONGO_PASSWORD = "test_password";
+  private static final String MONGO_IMAGE = "mongodb/mongodb-atlas-local";
+  private static final String MONGO_TAG = "latest";
+
+  private static final MongoDBAtlasLocalContainer MONGO_CONTAINER =
+      new MongoDBAtlasLocalContainer(MONGO_IMAGE + ":" + MONGO_TAG)
+          .withEnv("MONGODB_INITDB_ROOT_USERNAME", MONGO_USERNAME)
+          .withEnv("MONGODB_INITDB_ROOT_PASSWORD", MONGO_PASSWORD);
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MongoDBHelper.class);
 
@@ -50,6 +60,7 @@ public class MongoDBHelper
 
   @Override
   public void beforeAll(final ExtensionContext context) {
+    startMongoContainer();
     getMongoClient();
   }
 
@@ -73,6 +84,8 @@ public class MongoDBHelper
       mongoClient.close();
       mongoClient = null;
     }
+    connectionString = null;
+    closeMongoDbContainer();
   }
 
   public String getDatabaseName() {
@@ -95,5 +108,16 @@ public class MongoDBHelper
       LOGGER.info("Connecting to: '{}'", connectionString);
     }
     return connectionString;
+  }
+
+  public static void startMongoContainer() {
+    MONGO_CONTAINER.start();
+    String mongoURI = MONGO_CONTAINER.getConnectionString()
+        .replace("mongodb://", "mongodb://" + MONGO_USERNAME + ":" + MONGO_PASSWORD + "@");
+    System.setProperty(URI_SYSTEM_PROPERTY_NAME, mongoURI);
+  }
+
+  public static void closeMongoDbContainer() {
+    MONGO_CONTAINER.close();
   }
 }

--- a/src/integrationTest/java/com/mongodb/kafka/connect/sink/MongoSinkTaskIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/sink/MongoSinkTaskIntegrationTest.java
@@ -144,8 +144,7 @@ public class MongoSinkTaskIntegrationTest extends MongoKafkaTestCase {
               .anyMatch(
                   e -> {
                     String message = String.valueOf(e.getMessage());
-                    return message.contains("Failed to put into the sink the following records")
-                        && message.contains("{\"_id\": 4}");
+                    return message.contains("Failed to put 1 records into the sink");
                   }),
           () ->
               "Captured"
@@ -340,7 +339,7 @@ public class MongoSinkTaskIntegrationTest extends MongoKafkaTestCase {
       DataException e = assertThrows(DataException.class, () -> task.put(sinkRecords));
       assertTrue(
           e.getMessage()
-              .contains("Could not convert value 'a' (java.lang.String) into a BsonDocument"));
+              .contains("Could not convert value in topic:topic-test at partition:0 offset:0 into a BsonDocument."));
     }
   }
 

--- a/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
@@ -752,6 +752,7 @@ public class MongoSourceTaskIntegrationTest extends MongoKafkaTestCase {
                   MongoSourceConfig.COPY_EXISTING_PIPELINE_CONFIG,
                   "[{\"$match\": {\"myInt\": {\"$gt\": 10}}}]");
               put(MongoSourceConfig.POLL_MAX_BATCH_SIZE_CONFIG, "50");
+              put(MongoSourceConfig.DOCUMENT_KEY_AS_KEY_CONFIG, "true");
             }
           };
 

--- a/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest2.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest2.java
@@ -32,13 +32,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.connect.source.SourceTaskContext;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -66,6 +67,7 @@ import com.mongodb.event.CommandFailedEvent;
 import com.mongodb.event.CommandSucceededEvent;
 
 import com.mongodb.kafka.connect.util.jmx.SourceTaskStatistics;
+import com.mongodb.kafka.connect.mongodb.MongoDBHelper;
 
 /**
  * This class contains tests that are supposed to be unit tests, but because of how these tests were
@@ -89,12 +91,22 @@ class MongoSourceTaskIntegrationTest2 {
   private static final BsonDocument RESUME_TOKEN = BsonDocument.parse("{resume: 'token'}");
   private static final Map<String, Object> OFFSET = singletonMap("_id", RESUME_TOKEN.toJson());
 
+  @BeforeAll
+  static void setUp() {
+    MongoDBHelper.startMongoContainer();
+  }
+
+  @AfterAll
+  static void cleanUp() {
+    MongoDBHelper.closeMongoDbContainer();
+  }
+
   @Test
   @DisplayName("test creates the expected collection cursor")
   void testCreatesExpectedCollectionCursor() {
     MongoSourceTask task = new MongoSourceTask();
     Map<String, String> cfgMap = new HashMap<>();
-    cfgMap.put(CONNECTION_URI_CONFIG, "mongodb://localhost");
+    cfgMap.put(CONNECTION_URI_CONFIG, getConnectionString());
     cfgMap.put(DATABASE_CONFIG, TEST_DATABASE);
     cfgMap.put(COLLECTION_CONFIG, TEST_COLLECTION);
     MongoSourceConfig cfg = new MongoSourceConfig(cfgMap);
@@ -189,7 +201,7 @@ class MongoSourceTaskIntegrationTest2 {
   void testCreatesExpectedDatabaseCursor() {
     MongoSourceTask task = new MongoSourceTask();
     Map<String, String> cfgMap = new HashMap<>();
-    cfgMap.put(CONNECTION_URI_CONFIG, "mongodb://localhost");
+    cfgMap.put(CONNECTION_URI_CONFIG, getConnectionString());
     cfgMap.put(DATABASE_CONFIG, TEST_DATABASE);
     MongoSourceConfig cfg = new MongoSourceConfig(cfgMap);
     task.start(cfgMap);
@@ -277,7 +289,7 @@ class MongoSourceTaskIntegrationTest2 {
   void testCreatesExpectedClientCursor() {
     MongoSourceTask task = new MongoSourceTask();
     Map<String, String> cfgMap = new HashMap<>();
-    cfgMap.put(CONNECTION_URI_CONFIG, "mongodb://localhost");
+    cfgMap.put(CONNECTION_URI_CONFIG, getConnectionString());
     MongoSourceConfig cfg = new MongoSourceConfig(cfgMap);
     task.start(cfgMap);
 
@@ -389,7 +401,9 @@ class MongoSourceTaskIntegrationTest2 {
     String mBeanName =
         "com.mongodb.kafka.connect:type=source-task-metrics,connector=MongoSourceConnector,task=source-task-change-stream-unknown";
     MongoSourceTask task = new MongoSourceTask();
-    task.start(Collections.emptyMap());
+    Map<String, String> cfgMap = new HashMap<>();
+    cfgMap.put(CONNECTION_URI_CONFIG, getConnectionString());
+    task.start(cfgMap);
 
     task.commitRecord(null, new RecordMetadata(null, 0, 0, 0, 0L, 0, 0));
 
@@ -467,10 +481,14 @@ class MongoSourceTaskIntegrationTest2 {
     stats.unregister();
   }
 
-  private boolean isReplicaSetOrSharded() {
+  private String getConnectionString() {
     String defaultString = "mongodb://localhost:27017";
     String connectionString = System.getProperty("org.mongodb.test.uri", defaultString);
-    connectionString = connectionString.isEmpty() ? defaultString : connectionString;
+    return connectionString.isEmpty() ? defaultString : connectionString;
+  }
+
+  private boolean isReplicaSetOrSharded() {
+    String connectionString = getConnectionString();
     try (MongoClient mongoClient = MongoClients.create(connectionString)) {
       Document isMaster =
           mongoClient.getDatabase("admin").runCommand(BsonDocument.parse("{isMaster: 1}"));

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
@@ -305,7 +305,7 @@ class MongoSinkConfigTest {
   void testTopicRegexWithOverridesReDOS() {
     String safeRegex = "(a+)+";
     String unsafeRegex = "(a+)+b";
-    
+
     // Create a string that will definitely cause a timeout with the unsafe regex,
     // but not with the safe regex
     // The string contains only 'a's but the unsafe regex requires a 'b' at the end


### PR DESCRIPTION
## Fixed the integration tests
- There are total 85 integration tests in total. Fixed 7 of them.
- Current status is 81 Passing, 4 getting Skipped because they are for older versions only.

> - testBulkWriteOperationErrorWriteModelsIncludedInTheLog
>     - It was expecting content of key in the log, but we are not logging actual customer data from records.
>     - Fixed it by changing the expected message as per our logs.
> - testSinkCanHandleInvalidDocumentWhenErrorToleranceIsAll
>     - The reason is same, the test was expecting actual value in the error message.
> - testSourceEmitsNullValuesOnDelete
>     - We have changed the default value for DOCUMENT_KEY_AS_KEY_CONFIG as "false", while it is "true" in mongo repo.
>     - Fixed it by manually adding this config with value "true".
> - MongoSourceTaskIntegrationTest2
>     - 4 tests in this class, were explicitly looking for localhost.
>     - Changed them to have any connection string based on system property, or fall on default localhost.  

## Enabled docker instance for Mongodb to run the ITs
- MongoDB team written Integration tests was expecting a pre-setup mongodb instance to run the integration tests.
- Updated the code to use `testContainers`, which will automatically initiate docker instances of mongodb to run the test.

## Enabled integration tests in the semaphore pipeline
- The integration tests were disabled for MongoDB Atlas connector due to failures.
- Enabled them for semaphore, now on they will run upon every PR raise.