### PR TITLE
CC-32763: Set threadName with connector name and taskId prefix

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/source/MongoCopyDataManager.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoCopyDataManager.java
@@ -18,6 +18,7 @@ package com.mongodb.kafka.connect.source;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COLLECTION_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.DATABASE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.REGEX_TIMEOUT_MS;
+import static com.mongodb.kafka.connect.source.MongoSourceTask.TASK_ID_ZERO;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
@@ -36,6 +37,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
+import org.apache.kafka.common.utils.ThreadUtils;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,6 +71,7 @@ class MongoCopyDataManager implements AutoCloseable {
   private static final String NAMESPACE_FIELD = "ns";
   static final String ALT_NAMESPACE_FIELD = "__";
   private static final byte[] NAMESPACE_BYTES = NAMESPACE_FIELD.getBytes(StandardCharsets.UTF_8);
+  private static final String NAME = "name";
 
   private static final String PIPELINE_TEMPLATE =
       format(
@@ -106,9 +109,13 @@ class MongoCopyDataManager implements AutoCloseable {
     namespacesToCopy = new AtomicInteger(namespaces.size());
     CopyExistingConfig copyConfig = sourceConfig.getStartupConfig().copyExistingConfig();
     queue = new ArrayBlockingQueue<>(copyConfig.queueSize());
+    String connectorName = sourceConfig.originalsStrings().get(NAME);
+    String threadNamePattern =
+        connectorName + "-" + TASK_ID_ZERO + "-mongo-copy-data-manager-executor-%d";
     executor =
         Executors.newFixedThreadPool(
-            Math.max(1, Math.min(namespaces.size(), copyConfig.maxThreads())));
+            Math.max(1, Math.min(namespaces.size(), copyConfig.maxThreads())),
+            ThreadUtils.createThreadFactory(threadNamePattern, false));
     namespaces.forEach(n -> executor.submit(() -> copyDataFrom(n)));
   }
 

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -94,6 +94,11 @@ public final class MongoSourceTask extends SourceTask {
   private static final String NS_KEY = "ns";
   private static final int UNKNOWN_FIELD_ERROR = 40415;
   private static final int FAILED_TO_PARSE_ERROR = 9;
+  /**
+   * Since this is a single task connector, directly having task ID as "0" is safe.
+   * This should be passed from MongoSourceConnector.taskConfigs in case of multiple tasks.
+   */
+  public static final String TASK_ID_ZERO = "0";
 
   private StartedMongoSourceTask startedTask;
 

--- a/src/test/java/com/mongodb/kafka/connect/source/MongoCopyDataManagerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/MongoCopyDataManagerTest.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -126,6 +127,51 @@ class MongoCopyDataManagerTest {
 
     List<Optional<BsonDocument>> expected = asList(createOutput(jsonTemplate), Optional.empty());
     assertEquals(expected, results);
+  }
+
+  @Test
+  @DisplayName("threads are named with connector and task prefix for copy-existing executor")
+  void testThreadNamesForCopyExistingExecutor() {
+    String connectorName = "MyConnector";
+    String taskId = "0";
+    String jsonTemplate = createTemplate(1);
+
+    when(mongoClient.getDatabase(TEST_DATABASE)).thenReturn(mongoDatabase);
+    when(mongoDatabase.getCollection(TEST_COLLECTION, RawBsonDocument.class))
+        .thenReturn(mongoCollection);
+    when(mongoCollection.aggregate(anyList())).thenReturn(aggregateIterable);
+    when(aggregateIterable.allowDiskUse(COPY_EXISTING_ALLOW_DISK_USE_DEFAULT))
+        .thenReturn(aggregateIterable);
+    doCallRealMethod().when(aggregateIterable).forEach(any(Consumer.class));
+    when(aggregateIterable.iterator()).thenReturn(cursor);
+
+    when(cursor.hasNext()).thenReturn(true, false);
+
+    AtomicReference<String> threadNameRef = new AtomicReference<>();
+    when(cursor.next())
+        .thenAnswer(
+            invocation -> {
+              threadNameRef.set(Thread.currentThread().getName());
+              return createInput(jsonTemplate);
+            });
+
+    Map<String, String> props = new HashMap<>();
+    props.put(STARTUP_MODE_CONFIG, StartupMode.COPY_EXISTING.propertyValue());
+    props.put(DATABASE_CONFIG, TEST_DATABASE);
+    props.put(COLLECTION_CONFIG, TEST_COLLECTION);
+    props.put("name", connectorName);
+
+    try (MongoCopyDataManager copyExistingDataManager =
+             new MongoCopyDataManager(new MongoSourceConfig(props), mongoClient)) {
+      sleep(300);
+      copyExistingDataManager.poll();
+    }
+
+    String expectedPrefix = connectorName + "-" + taskId + "-mongo-copy-data-manager-executor-";
+    assertTrue(
+        threadNameRef.get() != null && threadNameRef.get().startsWith(expectedPrefix),
+        () -> "Expected thread name to start with '"
+            + expectedPrefix + "' but was '" + threadNameRef.get() + "'");
   }
 
   @Test


### PR DESCRIPTION
## Problem
The MongoDb Atlas Source connector spawns additional threads (via MongoCopyDataManager) to fetch data from Mongodb in parallel. The overall resource consumption is underestimated as these additional threads are not being tracked. This can lead to inaccurate task placement decisions, causing some workers to become overloaded while others remain underutilized.

## Solution
Implement a thread naming convention that allows the runtime to accurately track CPU time across all threads associated with a specific task by setting the thread name with a `connectorName + taskId` prefix. The thread naming pattern follows: {connectorName}-{taskId}-mongo-copy-data-manager-executor-{threadNumber}
Since, MongoDb Atlas Source connector is a single task connector - we will keep taskId = 0

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

For manual testing, I added a log displaying thread name and tested it out on devel.
[Log Link](https://opensearch-ue1.aws.devel.cpdev.cloud/_dashboards/app/discover#/doc/e64d6b00-5a33-11ef-ba73-2f94fbaa87a3/logs.json.connect-2025.09.07-000094?id=9_1101793965)
<img width="927" height="274" alt="image" src="https://github.com/user-attachments/assets/05adfb06-b2b7-4469-bcec-d5f616b8a0b8" />

Also verified that, The connector doesn't fail with Fail Fast Validations being on.
<img width="338" height="392" alt="image" src="https://github.com/user-attachments/assets/223624af-5a1d-4db9-b7b0-d68fdd10da14" />