### PR TITLE
Minor: Package avro dependency in connector build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ repositories {
 extra.apply {
     set("mongodbDriverVersion", "[4.7,4.7.99]")
     set("kafkaVersion", "2.6.0")
-    set("avroVersion", "1.9.2") // Upgrade dep to 1.12.x as part of 2.0.x connector version bump
+    set("avroVersion", "1.11.4") // Upgrade dep to 1.12.x as part of 2.0.x connector version bump
     set("connectUtilsVersion", "1.1.0")
 
     // Testing dependencies

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ repositories {
 extra.apply {
     set("mongodbDriverVersion", "[4.7,4.7.99]")
     set("kafkaVersion", "2.6.0")
-    set("avroVersion", "1.9.2")
+    set("avroVersion", "1.9.2") // Upgrade dep to 1.12.x as part of 2.0.x connector version bump
     set("connectUtilsVersion", "1.1.0")
 
     // Testing dependencies

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -244,7 +244,7 @@ tasks.named("compileJava") {
  */
 tasks.register<ShadowJar>("confluentJar") {
     archiveClassifier.set("confluent")
-    from(mongoDependencies, sourceSets.main.get().output)
+    from(mongoAndAvroDependencies, sourceSets.main.get().output)
 }
 
 tasks.register<ShadowJar>("allJar") {

--- a/src/integrationTest/java/com/mongodb/kafka/connect/mongodb/MongoDBHelper.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/mongodb/MongoDBHelper.java
@@ -37,7 +37,7 @@ public class MongoDBHelper
   private static final String MONGO_USERNAME = "test_username";
   private static final String MONGO_PASSWORD = "test_password";
   private static final String MONGO_IMAGE = "mongodb/mongodb-atlas-local";
-  private static final String MONGO_TAG = "latest";
+  private static final String MONGO_TAG = "8.0";
 
   private static final MongoDBAtlasLocalContainer MONGO_CONTAINER =
       new MongoDBAtlasLocalContainer(MONGO_IMAGE + ":" + MONGO_TAG)


### PR DESCRIPTION
Packaging avro dependency in connector build to ensure version bump for SR dependencies is not blocked in cloud. More context - SR version bump is bringing in upgraded avro dependency (1.11.4 → 1.12.1) which is breaking the existing mongo connector. 

```
java.lang.NoSuchMethodError: org.apache.avro.Schema$Parser.setValidate(Z)Lorg/apache/avro/Schema$Parser;
    at com.mongodb.kafka.connect.source.schema.AvroSchema.<init>(AvroSchema.java:142)
    at com.mongodb.kafka.connect.source.MongoSourceConfig.<clinit>(MongoSourceConfig.java:66)


After checking online, it looks like Avro 1.12.x has removed the setValidate(boolean) method, which explains the failure. ref: https://github.com/FasterXML/jackson-dataformats-binary/issues/514#issuecomment-2326828463
```

The fix we are looking to add currently is to pin the existing avro dependency version and package it in connector jar instead of using the runtime version. 
