### PR TITLE
Fix testSourceEmitsNullValuesOnDelete test

### DIFF
--- a/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
@@ -781,6 +781,9 @@ public class MongoSourceTaskIntegrationTest extends MongoKafkaTestCase {
           pollAfterDelete.stream()
               .map(r -> Document.parse(r.key().toString()).get("_id").toString())
               .collect(toList());
+      // Sorting the lists before comparing as the ids may arrive in any order
+      documentIds.sort(null);
+      connectRecordsKeyIds.sort(null);
       assertIterableEquals(documentIds, connectRecordsKeyIds);
     }
   }


### PR DESCRIPTION
The test `MongoSourceTaskIntegrationTest.testSourceEmitsNullValuesOnDelete` is failing due to ids arriving in different order. As part of this PR sorting the actual and expected id list before comparing.