### PR TITLE
CC-38701 Cherry Picks from v1.16.x branch onto v2.0.2 branch 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
-# Global owner for repo
-* @mongodb/kafka-connector-contributors
+# See go/codeowners - automatically generated for confluentinc/mongo-kafka:
+*	@confluentinc/connect
+*	@confluentinc/connect-cloud

--- a/.semaphore/project.yml
+++ b/.semaphore/project.yml
@@ -1,0 +1,43 @@
+# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
+# template and configurations in service.yml.
+# Modifications in this file will be overwritten by generated content in the nightly run.
+# For more information, please refer to the page:
+# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
+apiVersion: v1alpha
+kind: Project
+metadata:
+  name: mongo-kafka
+  description: ""
+spec:
+  visibility: private
+  repository:
+    url: git@github.com:confluentinc/mongo-kafka.git
+    run_on:
+      - branches
+      - pull_requests
+    pipeline_file: .semaphore/semaphore.yml
+    integration_type: github_app
+    status:
+      pipeline_files:
+        - path: .semaphore/semaphore.yml
+          level: pipeline
+    whitelist:
+      branches:
+        - master
+        - main
+        - /^\d+\.\d+\.x$/
+        - /^gh-readonly-queue.*/
+  custom_permissions: true
+  debug_permissions:
+    - empty
+    - default_branch
+    - non_default_branch
+    - pull_request
+    - forked_pull_request
+    - tag
+  attach_permissions:
+    - default_branch
+    - non_default_branch
+    - pull_request
+    - forked_pull_request
+    - tag

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -39,6 +39,7 @@ blocks:
             - pip install confluent-release-tools -q
             - . sem-pint -c
             - ./gradlew test
+            - ./gradlew integrationTest
             - . cve-scan
             - . cache-maven store
       epilogue:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,66 @@
+# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
+# template and configurations in service.yml.
+# Any modifications made to ths file will be overwritten by the generated content in nightly runs.
+# For more information, please refer to the page:
+# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
+version: v1.0
+name: build-test-release
+agent:
+  machine:
+    type: s1-prod-ubuntu24-04-amd64-1
+
+fail_fast:
+  cancel:
+    when: "true"
+
+execution_time_limit:
+  hours: 1
+
+queue:
+  - when: "branch != 'master' and branch !~ 'v[0-9]+\\.[0-9]+\\.x'"
+    processing: parallel
+
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+      - sem-version java 8
+
+blocks:
+  - name: Test
+    dependencies: []
+    run:
+      # don't run the tests on non-functional changes...
+      when: "change_in('/', {exclude: ['/.deployed-versions/', '.github/'], default_branch: 'master'})"
+    task:
+      jobs:
+        - name: Test
+          commands:
+            - pip install confluent-release-tools -q
+            - . sem-pint -c
+            - ./gradlew test
+            - . cve-scan
+            - . cache-maven store
+      epilogue:
+        always:
+          commands:
+            - . publish-test-results
+            - artifact push workflow target/test-results
+
+after_pipeline:
+  task:
+    agent:
+      machine:
+        type: s1-prod-ubuntu24-04-arm64-0
+    jobs:
+      - name: Metrics
+        commands:
+          - emit-ci-metrics -p -a test-results
+      - name: Publish Test Results
+        commands:
+          - test-results gen-pipeline-report
+      - name: SonarQube
+        commands:
+          - checkout
+          - sem-version java 11
+          - emit-sonarqube-data -a test-results

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -63,5 +63,5 @@ after_pipeline:
       - name: SonarQube
         commands:
           - checkout
-          - sem-version java 11
-          - emit-sonarqube-data -a test-results
+          - sem-version java 17
+          - emit-sonarqube-data --enable_sonarqube_enterprise

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,7 @@ extra.apply {
     set("mongodbDriverVersion", "[4.7,4.7.99]")
     set("kafkaVersion", "3.9.1")
     set("avroVersion", "1.12.1")
+    set("connectUtilsVersion", "1.1.0")
 }
 
 val mongoAndAvroDependencies: Configuration by configurations.creating
@@ -80,9 +81,11 @@ dependencies {
     }
     implementation("org.mongodb:mongodb-driver-sync:${project.extra["mongodbDriverVersion"]}")
     implementation("org.apache.avro:avro:${project.extra["avroVersion"]}")
+    implementation("com.github.jcustenborder.kafka.connect:connect-utils:${project.extra["connectUtilsVersion"]}")
 
     mongoAndAvroDependencies("org.mongodb:mongodb-driver-sync:${project.extra["mongodbDriverVersion"]}")
     mongoAndAvroDependencies("org.apache.avro:avro:${project.extra["avroVersion"]}")
+    mongoAndAvroDependencies("com.github.jcustenborder.kafka.connect:connect-utils:${project.extra["connectUtilsVersion"]}")
 
     // Unit Tests
     testImplementation(platform("org.junit:junit-bom:5.8.1"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,7 @@ extra.apply {
     set("kafkaVersion", "3.9.1")
     set("avroVersion", "1.12.1")
     set("connectUtilsVersion", "1.1.0")
+    set("testcontainersVersion", "1.21.3")
 }
 
 val mongoAndAvroDependencies: Configuration by configurations.creating
@@ -115,6 +116,10 @@ dependencies {
     // This lets us output logs for the integration tests which is required for tests that capture
     // logs to verify functionality.
     testImplementation("org.slf4j:slf4j-reload4j:2.0.13")
+    testImplementation(platform("org.testcontainers:testcontainers-bom:${project.extra["testcontainersVersion"]}"))
+    testImplementation("org.testcontainers:testcontainers")
+    testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("org.testcontainers:mongodb")
 }
 
 tasks.withType<JavaCompile> {
@@ -230,7 +235,7 @@ checkstyle {
 }
 
 spotbugs {
-    toolVersion.set("4.9.8")
+    toolVersion.set("4.8.0")
     excludeFilter.set(project.file("config/spotbugs-exclude.xml"))
     showProgress.set(true)
     setReportLevel("high")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -248,31 +248,6 @@ tasks.withType<com.github.spotbugs.snom.SpotBugsTask> {
     reports.maybeCreate("xml").isEnabled = project.hasProperty("xmlReports.enabled")
 }
 
-// Spotless is used to lint and reformat source files.
-spotless {
-    java {
-        googleJavaFormat("1.12.0")
-        importOrder("java", "io", "org", "org.bson", "com.mongodb", "com.mongodb.kafka", "")
-        removeUnusedImports() // removes any unused imports
-        trimTrailingWhitespace()
-        endWithNewline()
-        indentWithSpaces()
-    }
-
-    kotlinGradle {
-        ktlint("0.31.0")
-        trimTrailingWhitespace()
-        indentWithSpaces()
-        endWithNewline()
-    }
-
-    format("extraneous") {
-        target("*.xml", "*.yml", "*.md")
-        trimTrailingWhitespace()
-        indentWithSpaces()
-        endWithNewline()
-    }
-}
 
 // Configure CycloneDX SBOM generation
 tasks.named<CycloneDxTask>("cyclonedxBom") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ repositories {
 }
 
 extra.apply {
-    set("mongodbDriverVersion", "[4.7,4.7.99]")
+    set("mongodbDriverVersion", "[5.6,5.6.99]")
     set("kafkaVersion", "3.9.1")
     set("avroVersion", "1.12.1")
     set("connectUtilsVersion", "1.1.0")
@@ -120,7 +120,7 @@ dependencies {
     testImplementation("org.testcontainers:testcontainers")
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:mongodb")
-}
+   }
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.java.installations.auto-download=false
 org.gradle.java.installations.fromEnv=JDK8,JDK17
-org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xmx1G --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xmx1G

--- a/service.yml
+++ b/service.yml
@@ -1,0 +1,13 @@
+name: mongo-kafka
+lang: java
+lang_version: 8
+git:
+  enable: true
+codeowners:
+  enable: true
+semaphore:
+  enable: true
+  pipeline_type: cp
+  cve_scan: true
+  extra_deploy_args: "-Dcloud -Pjenkins"
+  extra_build_args: "-Dcloud -Pjenkins"

--- a/service.yml
+++ b/service.yml
@@ -7,7 +7,9 @@ codeowners:
   enable: true
 semaphore:
   enable: true
-  pipeline_type: cp
+  pipeline_type: false
   cve_scan: true
   extra_deploy_args: "-Dcloud -Pjenkins"
   extra_build_args: "-Dcloud -Pjenkins"
+sonarqube:
+  enable: true

--- a/service.yml
+++ b/service.yml
@@ -7,7 +7,7 @@ codeowners:
   enable: true
 semaphore:
   enable: true
-  pipeline_type: false
+  pipeline_enable: false
   cve_scan: true
   extra_deploy_args: "-Dcloud -Pjenkins"
   extra_build_args: "-Dcloud -Pjenkins"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,7 @@
 ### service-bot sonarqube plugin managed file
 sonar.coverage.exclusions=**/test/**/*,**/tests/**/*,**/mock/**/*,**/mocks/**/*,**/*mock*,**/*test*
 sonar.coverage.jacoco.xmlReportPaths=**/jacoco.xml
+sonar.cpd.exclusions=**/test/**/*,**/tests/**/*,**/mock/**/*,**/mocks/**/*,**/*mock*,**/*test*
 sonar.exclusions=**/*.pb.*,**/mk-include/**/*
 sonar.java.binaries=.
 sonar.language=java

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+### service-bot sonarqube plugin managed file
+sonar.coverage.exclusions=**/test/**/*,**/tests/**/*,**/mock/**/*,**/mocks/**/*,**/*mock*,**/*test*
+sonar.coverage.jacoco.xmlReportPaths=**/jacoco.xml
+sonar.exclusions=**/*.pb.*,**/mk-include/**/*
+sonar.java.binaries=.
+sonar.language=java
+sonar.projectKey=mongo-kafka
+sonar.sources=.

--- a/src/integrationTest/java/com/mongodb/kafka/connect/ConnectorValidationIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/ConnectorValidationIntegrationTest.java
@@ -400,6 +400,12 @@ public final class ConnectorValidationIntegrationTest {
   }
 
   @Test
+  @DisplayName("Ensure source configuration validation handles invalid connection host in Url")
+  void testSourceConfigValidationInvalidConnectionUrl() {
+    assertInvalidSource(createSourceProperties("mongodb+srv://mongo:mongo@27017"));
+  }
+
+  @Test
   @DisplayName("Ensure source configuration validation works with invalid serverApi")
   void testSourceConfigValidationWithInvalidServerApi() {
     assumeFalse(isAtleastFiveDotZero(getMongoClient()));

--- a/src/integrationTest/java/com/mongodb/kafka/connect/ConnectorValidationIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/ConnectorValidationIntegrationTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeAll;
 
 import org.bson.BsonDocument;
 import org.bson.Document;
@@ -55,6 +56,7 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
 
+import com.mongodb.kafka.connect.mongodb.MongoDBHelper;
 import com.mongodb.kafka.connect.sink.MongoSinkConfig;
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
 import com.mongodb.kafka.connect.source.MongoSourceConfig;
@@ -73,11 +75,17 @@ public final class ConnectorValidationIntegrationTest {
   private static final String CUSTOM_COLLECTION = "customCollection";
   private static MongoClient mongoClient;
 
+  @BeforeAll
+  static void setUp() {
+    MongoDBHelper.startMongoContainer();
+  }
+
   @AfterAll
   static void done() {
     if (mongoClient != null) {
       mongoClient.close();
     }
+    MongoDBHelper.closeMongoDbContainer();
   }
 
   @AfterEach

--- a/src/integrationTest/java/com/mongodb/kafka/connect/mongodb/MongoDBHelper.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/mongodb/MongoDBHelper.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.mongodb.MongoDBAtlasLocalContainer;
 
 import com.mongodb.ConnectionString;
 import com.mongodb.client.MongoClient;
@@ -33,6 +34,15 @@ public class MongoDBHelper
   private static final String DEFAULT_URI = "mongodb://localhost:27017";
   private static final String URI_SYSTEM_PROPERTY_NAME = "org.mongodb.test.uri";
   private static final String DEFAULT_DATABASE_NAME = "MongoKafkaTest";
+  private static final String MONGO_USERNAME = "test_username";
+  private static final String MONGO_PASSWORD = "test_password";
+  private static final String MONGO_IMAGE = "mongodb/mongodb-atlas-local";
+  private static final String MONGO_TAG = "latest";
+
+  private static final MongoDBAtlasLocalContainer MONGO_CONTAINER =
+      new MongoDBAtlasLocalContainer(MONGO_IMAGE + ":" + MONGO_TAG)
+          .withEnv("MONGODB_INITDB_ROOT_USERNAME", MONGO_USERNAME)
+          .withEnv("MONGODB_INITDB_ROOT_PASSWORD", MONGO_PASSWORD);
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MongoDBHelper.class);
 
@@ -50,6 +60,7 @@ public class MongoDBHelper
 
   @Override
   public void beforeAll(final ExtensionContext context) {
+    startMongoContainer();
     getMongoClient();
   }
 
@@ -73,6 +84,8 @@ public class MongoDBHelper
       mongoClient.close();
       mongoClient = null;
     }
+    connectionString = null;
+    closeMongoDbContainer();
   }
 
   public String getDatabaseName() {
@@ -95,5 +108,16 @@ public class MongoDBHelper
       LOGGER.info("Connecting to: '{}'", connectionString);
     }
     return connectionString;
+  }
+
+  public static void startMongoContainer() {
+    MONGO_CONTAINER.start();
+    String mongoURI = MONGO_CONTAINER.getConnectionString()
+        .replace("mongodb://", "mongodb://" + MONGO_USERNAME + ":" + MONGO_PASSWORD + "@");
+    System.setProperty(URI_SYSTEM_PROPERTY_NAME, mongoURI);
+  }
+
+  public static void closeMongoDbContainer() {
+    MONGO_CONTAINER.close();
   }
 }

--- a/src/integrationTest/java/com/mongodb/kafka/connect/sink/MongoSinkTaskIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/sink/MongoSinkTaskIntegrationTest.java
@@ -144,8 +144,7 @@ public class MongoSinkTaskIntegrationTest extends MongoKafkaTestCase {
               .anyMatch(
                   e -> {
                     String message = String.valueOf(e.getMessage());
-                    return message.contains("Failed to put into the sink the following records")
-                        && message.contains("{\"_id\": 4}");
+                    return message.contains("Failed to put 1 records into the sink");
                   }),
           () ->
               "Captured"
@@ -340,7 +339,7 @@ public class MongoSinkTaskIntegrationTest extends MongoKafkaTestCase {
       DataException e = assertThrows(DataException.class, () -> task.put(sinkRecords));
       assertTrue(
           e.getMessage()
-              .contains("Could not convert value 'a' (java.lang.String) into a BsonDocument"));
+              .contains("Could not convert value in topic:topic-test at partition:0 offset:0 into a BsonDocument."));
     }
   }
 

--- a/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
@@ -999,8 +999,7 @@ public class MongoSourceTaskIntegrationTest extends MongoKafkaTestCase {
               .filter(e -> e.getLevel().equals(Level.ERROR))
               .anyMatch(
                   e ->
-                      e.getMessage()
-                          .toString()
+                      e.getRenderedMessage()
                           .startsWith(
                               "Failed to resume change stream: Query failed with error code 10334")));
 

--- a/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
@@ -999,9 +999,8 @@ public class MongoSourceTaskIntegrationTest extends MongoKafkaTestCase {
               .filter(e -> e.getLevel().equals(Level.ERROR))
               .anyMatch(
                   e ->
-                      e.getRenderedMessage()
-                          .startsWith(
-                              "Failed to resume change stream: Query failed with error code 10334")));
+                      e.getRenderedMessage().contains("Failed to resume change stream")
+                          && e.getRenderedMessage().contains("10334")));
 
       Map<String, Map<String, Long>> mBeansMap =
           getMBeanAttributes(

--- a/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
@@ -781,6 +781,9 @@ public class MongoSourceTaskIntegrationTest extends MongoKafkaTestCase {
           pollAfterDelete.stream()
               .map(r -> Document.parse(r.key().toString()).get("_id").toString())
               .collect(toList());
+      // Sorting the lists before comparing as the ids may arrive in any order
+      documentIds.sort(null);
+      connectRecordsKeyIds.sort(null);
       assertIterableEquals(documentIds, connectRecordsKeyIds);
     }
   }

--- a/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
@@ -903,8 +903,7 @@ public class MongoSourceTaskIntegrationTest extends MongoKafkaTestCase {
           task.logCapture.getEvents().stream()
               .filter(e -> e.getLevel().equals(Level.ERROR))
               .anyMatch(
-                  e ->
-                      e.getMessage().toString().contains("Exception creating Source record for:")));
+                  e -> e.getMessage().toString().contains("Exception creating Source record")));
 
       // Reset and test copy existing without logs
       task.stop();
@@ -922,7 +921,7 @@ public class MongoSourceTaskIntegrationTest extends MongoKafkaTestCase {
               .findFirst()
               .map(e -> e.getMessage().toString())
               .orElseGet(() -> "")
-              .contains("Exception creating Source record for:"));
+              .contains("Exception creating Source record"));
       task.stop();
     }
   }
@@ -956,7 +955,7 @@ public class MongoSourceTaskIntegrationTest extends MongoKafkaTestCase {
       insertMany(rangeClosed(4, 5), coll);
 
       Exception e = assertThrows(DataException.class, () -> getNextResults(task));
-      assertTrue(e.getMessage().contains("Exception creating Source record for:"));
+      assertTrue(e.getMessage().contains("Exception creating Source record"));
     }
   }
 

--- a/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest.java
@@ -752,6 +752,7 @@ public class MongoSourceTaskIntegrationTest extends MongoKafkaTestCase {
                   MongoSourceConfig.COPY_EXISTING_PIPELINE_CONFIG,
                   "[{\"$match\": {\"myInt\": {\"$gt\": 10}}}]");
               put(MongoSourceConfig.POLL_MAX_BATCH_SIZE_CONFIG, "50");
+              put(MongoSourceConfig.DOCUMENT_KEY_AS_KEY_CONFIG, "true");
             }
           };
 

--- a/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest2.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest2.java
@@ -32,13 +32,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.connect.source.SourceTaskContext;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -66,6 +67,7 @@ import com.mongodb.event.CommandFailedEvent;
 import com.mongodb.event.CommandSucceededEvent;
 
 import com.mongodb.kafka.connect.util.jmx.SourceTaskStatistics;
+import com.mongodb.kafka.connect.mongodb.MongoDBHelper;
 
 /**
  * This class contains tests that are supposed to be unit tests, but because of how these tests were
@@ -89,12 +91,22 @@ class MongoSourceTaskIntegrationTest2 {
   private static final BsonDocument RESUME_TOKEN = BsonDocument.parse("{resume: 'token'}");
   private static final Map<String, Object> OFFSET = singletonMap("_id", RESUME_TOKEN.toJson());
 
+  @BeforeAll
+  static void setUp() {
+    MongoDBHelper.startMongoContainer();
+  }
+
+  @AfterAll
+  static void cleanUp() {
+    MongoDBHelper.closeMongoDbContainer();
+  }
+
   @Test
   @DisplayName("test creates the expected collection cursor")
   void testCreatesExpectedCollectionCursor() {
     MongoSourceTask task = new MongoSourceTask();
     Map<String, String> cfgMap = new HashMap<>();
-    cfgMap.put(CONNECTION_URI_CONFIG, "mongodb://localhost");
+    cfgMap.put(CONNECTION_URI_CONFIG, getConnectionString());
     cfgMap.put(DATABASE_CONFIG, TEST_DATABASE);
     cfgMap.put(COLLECTION_CONFIG, TEST_COLLECTION);
     MongoSourceConfig cfg = new MongoSourceConfig(cfgMap);
@@ -189,7 +201,7 @@ class MongoSourceTaskIntegrationTest2 {
   void testCreatesExpectedDatabaseCursor() {
     MongoSourceTask task = new MongoSourceTask();
     Map<String, String> cfgMap = new HashMap<>();
-    cfgMap.put(CONNECTION_URI_CONFIG, "mongodb://localhost");
+    cfgMap.put(CONNECTION_URI_CONFIG, getConnectionString());
     cfgMap.put(DATABASE_CONFIG, TEST_DATABASE);
     MongoSourceConfig cfg = new MongoSourceConfig(cfgMap);
     task.start(cfgMap);
@@ -277,7 +289,7 @@ class MongoSourceTaskIntegrationTest2 {
   void testCreatesExpectedClientCursor() {
     MongoSourceTask task = new MongoSourceTask();
     Map<String, String> cfgMap = new HashMap<>();
-    cfgMap.put(CONNECTION_URI_CONFIG, "mongodb://localhost");
+    cfgMap.put(CONNECTION_URI_CONFIG, getConnectionString());
     MongoSourceConfig cfg = new MongoSourceConfig(cfgMap);
     task.start(cfgMap);
 
@@ -389,7 +401,9 @@ class MongoSourceTaskIntegrationTest2 {
     String mBeanName =
         "com.mongodb.kafka.connect:type=source-task-metrics,connector=MongoSourceConnector,task=source-task-change-stream-unknown";
     MongoSourceTask task = new MongoSourceTask();
-    task.start(Collections.emptyMap());
+    Map<String, String> cfgMap = new HashMap<>();
+    cfgMap.put(CONNECTION_URI_CONFIG, getConnectionString());
+    task.start(cfgMap);
 
     task.commitRecord(null, new RecordMetadata(null, 0, 0, 0, 0L, 0, 0));
 
@@ -467,10 +481,14 @@ class MongoSourceTaskIntegrationTest2 {
     stats.unregister();
   }
 
-  private boolean isReplicaSetOrSharded() {
+  private String getConnectionString() {
     String defaultString = "mongodb://localhost:27017";
     String connectionString = System.getProperty("org.mongodb.test.uri", defaultString);
-    connectionString = connectionString.isEmpty() ? defaultString : connectionString;
+    return connectionString.isEmpty() ? defaultString : connectionString;
+  }
+
+  private boolean isReplicaSetOrSharded() {
+    String connectionString = getConnectionString();
     try (MongoClient mongoClient = MongoClients.create(connectionString)) {
       Document isMaster =
           mongoClient.getDatabase("admin").runCommand(BsonDocument.parse("{isMaster: 1}"));

--- a/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest2.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/source/MongoSourceTaskIntegrationTest2.java
@@ -431,7 +431,7 @@ class MongoSourceTaskIntegrationTest2 {
     SourceTaskStatistics stats = new SourceTaskStatistics(mBeanName);
     stats.register();
     MongoSourceTask.mongoCommandSucceeded(
-        new CommandSucceededEvent(0, null, "getMore", new BsonDocument(), 100000000), stats);
+        new CommandSucceededEvent(null, 0L, 0, null, "test", "getMore", new BsonDocument(), 100000000L), stats);
     for (Map<String, Long> attrs : getMBeanAttributes(mBeanName).values()) {
       assertEquals(1, attrs.get("getmore-commands-successful"));
       assertEquals(100, attrs.get("getmore-commands-successful-duration-ms"));
@@ -444,7 +444,7 @@ class MongoSourceTaskIntegrationTest2 {
     stats = new SourceTaskStatistics(mBeanName);
     stats.register();
     MongoSourceTask.mongoCommandSucceeded(
-        new CommandSucceededEvent(0, null, "aggregate", new BsonDocument(), 100000000), stats);
+        new CommandSucceededEvent(null, 0L, 0, null, "test", "aggregate", new BsonDocument(), 100000000L), stats);
     for (Map<String, Long> attrs : getMBeanAttributes(mBeanName).values()) {
       assertEquals(1, attrs.get("initial-commands-successful"));
       assertEquals(100, attrs.get("initial-commands-successful-duration-ms"));
@@ -457,7 +457,7 @@ class MongoSourceTaskIntegrationTest2 {
     stats = new SourceTaskStatistics(mBeanName);
     stats.register();
     MongoSourceTask.mongoCommandFailed(
-        new CommandFailedEvent(0, null, "getMore", 100000000, null), stats);
+        new CommandFailedEvent(null, 0L, 0, null, "test", "getMore", 100000000L, null), stats);
     for (Map<String, Long> attrs : getMBeanAttributes(mBeanName).values()) {
       assertEquals(1, attrs.get("getmore-commands-failed"));
       assertEquals(100, attrs.get("getmore-commands-failed-duration-ms"));
@@ -470,7 +470,7 @@ class MongoSourceTaskIntegrationTest2 {
     stats = new SourceTaskStatistics(mBeanName);
     stats.register();
     MongoSourceTask.mongoCommandFailed(
-        new CommandFailedEvent(0, null, "aggregate", 100000000, null), stats);
+        new CommandFailedEvent(null, 0L, 0, null, "test", "aggregate", 100000000L, null), stats);
     for (Map<String, Long> attrs : getMBeanAttributes(mBeanName).values()) {
       assertEquals(1, attrs.get("initial-commands-failed"));
       assertEquals(100, attrs.get("initial-commands-failed-duration-ms"));

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordData.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordData.java
@@ -106,7 +106,12 @@ final class MongoProcessedSinkRecordData {
     } catch (Exception e) {
       exception = e;
       if (config.logErrors()) {
-        LOGGER.error("Unable to process record {}", sinkRecord, e);
+        LOGGER.error(
+            "Unable to process record in topic:{} at partition:{}, offset:{}",
+            sinkRecord.topic(),
+            sinkRecord.kafkaPartition(),
+            sinkRecord.kafkaOffset(),
+            e);
       }
       if (!(config.tolerateErrors() || config.tolerateDataErrors())) {
         throw e;

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
@@ -33,11 +33,14 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 import static org.apache.kafka.common.config.ConfigDef.Width;
+import com.github.jcustenborder.kafka.connect.utils.RegexUtils;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -74,6 +77,14 @@ public class MongoSinkConfig extends AbstractConfig {
   private static final String TOPICS_REGEX_DEFAULT = EMPTY_STRING;
   private static final String TOPICS_REGEX_DISPLAY = "Topics regex";
 
+  public static final String REGEX_TIMEOUT_MS = "regex.timeout.ms";
+  public static final long REGEX_TIMEOUT_MS_DEFAULT = 100L;
+  private static final String REGEX_TIMEOUT_MS_DOC =
+      "Timeout in milliseconds for any regex operation. This controls how long the connector will "
+          + "wait for regex pattern compilation, matching, replacement, or any other regex-related "
+          + "operation to complete before timing out.";
+  private static final String REGEX_TIMEOUT_MS_DISPLAY = "Regex Timeout (ms)";
+
   public static final String CONNECTION_URI_CONFIG = "connection.uri";
   private static final String CONNECTION_URI_DEFAULT = "mongodb://localhost:27017";
   private static final String CONNECTION_URI_DISPLAY = "MongoDB Connection URI";
@@ -93,6 +104,16 @@ public class MongoSinkConfig extends AbstractConfig {
           + "' and '"
           + TOPICS_CONFIG
           + "' are overridable.";
+
+  private static final String TOPIC_OVERRIDE_REGEX_TIMEOUT_ERROR_MESSAGE =
+      "Regex match operation timed out after %dms. "
+          + "A topic in one of the %s* configurations is causing the timeout when matching against %s. "
+          + "Please check your configurations.";
+
+  private static final String TOPIC_OVERRIDE_REGEX_ERROR_MESSAGE =
+      "Error during regex match: %s. "
+          + "A topic in one of the %s* configurations is causing an error when matching against %s. "
+          + "Please check your configurations.";
 
   static final String PROVIDER_CONFIG = "provider";
 
@@ -138,15 +159,35 @@ public class MongoSinkConfig extends AbstractConfig {
     // Process and validate overrides of regex values.
     if (topicsRegex.isPresent()) {
       Pattern topicRegex = topicsRegex.get();
+      long regexTimeoutDuration = getLong(REGEX_TIMEOUT_MS);
       originals.keySet().stream()
           .filter(k -> k.startsWith(TOPIC_OVERRIDE_PREFIX))
           .forEach(
               k -> {
                 String topic = k.substring(TOPIC_OVERRIDE_PREFIX.length()).split("\\.")[0];
-                if (!topicSinkConnectorConfigMap.containsKey(topic)
-                    && topicRegex.matcher(topic).matches()) {
-                  topicSinkConnectorConfigMap.put(
-                      topic, new MongoSinkTopicConfig(topic, originals));
+                if (!topicSinkConnectorConfigMap.containsKey(topic)) {
+                    try {
+                        if (RegexUtils.matches(topicRegex, topic, regexTimeoutDuration)) {
+                            topicSinkConnectorConfigMap.put(
+                                topic, new MongoSinkTopicConfig(topic, originals));
+                        }
+                    } catch (TimeoutException e) {
+                      String message = format(
+                          TOPIC_OVERRIDE_REGEX_TIMEOUT_ERROR_MESSAGE, regexTimeoutDuration,
+                          TOPIC_OVERRIDE_PREFIX, TOPICS_REGEX_CONFIG);
+                      throw new ConfigException(message);
+                    } catch (InterruptedException e) {
+                      Thread.currentThread().interrupt();
+                      String message = format(
+                          TOPIC_OVERRIDE_REGEX_ERROR_MESSAGE, e.getMessage(),
+                          TOPIC_OVERRIDE_PREFIX, TOPICS_REGEX_CONFIG);
+                      throw new ConfigException(message);
+                    } catch (ExecutionException e) {
+                      String message = format(
+                          TOPIC_OVERRIDE_REGEX_ERROR_MESSAGE, e.getMessage(),
+                          TOPIC_OVERRIDE_PREFIX, TOPICS_REGEX_CONFIG);
+                      throw new ConfigException(message);
+                    }
                 }
               });
     }
@@ -183,6 +224,10 @@ public class MongoSinkConfig extends AbstractConfig {
 
   public Map<String, String> getOriginals() {
     return originals;
+  }
+
+  public long getRegexTimeoutMs() {
+    return getLong(REGEX_TIMEOUT_MS);
   }
 
   public MongoSinkTopicConfig getMongoSinkTopicConfig(final String topic) {
@@ -282,6 +327,7 @@ public class MongoSinkConfig extends AbstractConfig {
         Width.MEDIUM,
         TOPICS_REGEX_DISPLAY);
 
+
     configDef.define(
         CONNECTION_URI_CONFIG,
         Type.PASSWORD,
@@ -310,6 +356,18 @@ public class MongoSinkConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         TOPIC_OVERRIDE_DISPLAY);
+
+    configDef.define(
+      REGEX_TIMEOUT_MS,
+      ConfigDef.Type.LONG,
+      REGEX_TIMEOUT_MS_DEFAULT,
+      ConfigDef.Range.atLeast(1),
+      ConfigDef.Importance.LOW,
+      REGEX_TIMEOUT_MS_DOC,
+      group,
+      ++orderInGroup,
+      ConfigDef.Width.SHORT,
+      REGEX_TIMEOUT_MS_DISPLAY);
 
     configDef.defineInternal(PROVIDER_CONFIG, Type.STRING, "", Importance.LOW);
 

--- a/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
@@ -244,6 +244,6 @@ final class StartedMongoSinkTask implements AutoCloseable {
   }
 
   private static void log(final Collection<SinkRecord> records, final RuntimeException e) {
-    LOGGER.error("Failed to put into the sink the following records: {}", records, e);
+    LOGGER.error("Failed to put {} records into the sink", records.size(), e);
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/ChangeStreamHandler.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/ChangeStreamHandler.java
@@ -64,10 +64,7 @@ public final class ChangeStreamHandler extends CdcHandler {
     BsonDocument changeStreamDocument = doc.getValueDoc().orElseGet(BsonDocument::new);
 
     if (!changeStreamDocument.containsKey(OPERATION_TYPE)) {
-      throw new DataException(
-          format(
-              "Error: `%s` field is doc is missing. %s",
-              OPERATION_TYPE, changeStreamDocument.toJson()));
+      throw new DataException(format("Error: `%s` field in doc is missing", OPERATION_TYPE));
     } else if (!changeStreamDocument.get(OPERATION_TYPE).isString()) {
       throw new DataException("Error: Unexpected CDC operation type, should be a string");
     }
@@ -76,9 +73,6 @@ public final class ChangeStreamHandler extends CdcHandler {
         OperationType.fromString(changeStreamDocument.get(OPERATION_TYPE).asString().getValue());
 
     LOGGER.debug("Creating operation handler for: {}", operationType);
-    if (LOGGER.isTraceEnabled()) {
-      LOGGER.trace("ChangeStream document {}", changeStreamDocument.toJson());
-    }
 
     if (OPERATIONS.containsKey(operationType)) {
       return Optional.of(OPERATIONS.get(operationType).perform(doc));

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/OperationHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/OperationHelper.java
@@ -48,13 +48,12 @@ final class OperationHelper {
 
   static BsonDocument getDocumentKey(final BsonDocument changeStreamDocument) {
     if (!changeStreamDocument.containsKey(DOCUMENT_KEY)) {
-      throw new DataException(
-          format("Missing %s field: %s", DOCUMENT_KEY, changeStreamDocument.toJson()));
+      throw new DataException(format("Missing %s field", DOCUMENT_KEY));
     } else if (!changeStreamDocument.get(DOCUMENT_KEY).isDocument()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expecting a document but found `%s`: %s",
-              DOCUMENT_KEY, changeStreamDocument.get(DOCUMENT_KEY), changeStreamDocument.toJson()));
+              "Unexpected %s field type, expecting a document but found `%s`",
+              DOCUMENT_KEY, changeStreamDocument.get(DOCUMENT_KEY)));
     }
 
     return changeStreamDocument.getDocument(DOCUMENT_KEY);
@@ -66,15 +65,12 @@ final class OperationHelper {
 
   static BsonDocument getFullDocument(final BsonDocument changeStreamDocument) {
     if (!changeStreamDocument.containsKey(FULL_DOCUMENT)) {
-      throw new DataException(
-          format("Missing %s field: %s", FULL_DOCUMENT, changeStreamDocument.toJson()));
+      throw new DataException(format("Missing %s field", FULL_DOCUMENT));
     } else if (!changeStreamDocument.get(FULL_DOCUMENT).isDocument()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expecting a document but found `%s`: %s",
-              FULL_DOCUMENT,
-              changeStreamDocument.get(FULL_DOCUMENT),
-              changeStreamDocument.toJson()));
+              "Unexpected %s field type, expecting a document but found `%s`",
+              FULL_DOCUMENT, changeStreamDocument.get(FULL_DOCUMENT)));
     }
 
     return changeStreamDocument.getDocument(FULL_DOCUMENT);
@@ -82,15 +78,12 @@ final class OperationHelper {
 
   static BsonDocument getUpdateDocument(final BsonDocument changeStreamDocument) {
     if (!changeStreamDocument.containsKey(UPDATE_DESCRIPTION)) {
-      throw new DataException(
-          format("Missing %s field: %s", UPDATE_DESCRIPTION, changeStreamDocument.toJson()));
+      throw new DataException(format("Missing %s field", UPDATE_DESCRIPTION));
     } else if (!changeStreamDocument.get(UPDATE_DESCRIPTION).isDocument()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expected a document found `%s`: %s",
-              UPDATE_DESCRIPTION,
-              changeStreamDocument.get(UPDATE_DESCRIPTION),
-              changeStreamDocument.toJson()));
+              "Unexpected %s field type, expected a document found `%s`",
+              UPDATE_DESCRIPTION, changeStreamDocument.get(UPDATE_DESCRIPTION)));
     }
 
     BsonDocument updateDescription = changeStreamDocument.getDocument(UPDATE_DESCRIPTION);
@@ -99,32 +92,26 @@ final class OperationHelper {
     if (!updateDescriptionFields.isEmpty()) {
       throw new DataException(
           format(
-              "Warning unexpected field(s) in %s %s. %s. Cannot process due to risk of data loss.",
-              UPDATE_DESCRIPTION, updateDescriptionFields, updateDescription.toJson()));
+              "Warning unexpected field(s) in %s %s. Cannot process due to risk of data loss.",
+              UPDATE_DESCRIPTION, updateDescriptionFields));
     }
 
     if (!updateDescription.containsKey(UPDATED_FIELDS)) {
-      throw new DataException(
-          format(
-              "Missing %s.%s field: %s",
-              UPDATE_DESCRIPTION, UPDATED_FIELDS, updateDescription.toJson()));
+      throw new DataException(format("Missing %s.%s field", UPDATE_DESCRIPTION, UPDATED_FIELDS));
     } else if (!updateDescription.get(UPDATED_FIELDS).isDocument()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expected a document but found `%s`: %s",
-              UPDATE_DESCRIPTION, updateDescription, updateDescription.toJson()));
+              "Unexpected %s field type, expected a document but found `%s`",
+              UPDATE_DESCRIPTION, updateDescription));
     }
 
     if (!updateDescription.containsKey(REMOVED_FIELDS)) {
-      throw new DataException(
-          format(
-              "Missing %s.%s field: %s",
-              UPDATE_DESCRIPTION, REMOVED_FIELDS, updateDescription.toJson()));
+      throw new DataException(format("Missing %s.%s field", UPDATE_DESCRIPTION, REMOVED_FIELDS));
     } else if (!updateDescription.get(REMOVED_FIELDS).isArray()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expected an array but found `%s`: %s",
-              REMOVED_FIELDS, updateDescription.get(REMOVED_FIELDS), updateDescription.toJson()));
+              "Unexpected %s field type, expected an array but found `%s`",
+              REMOVED_FIELDS, updateDescription.get(REMOVED_FIELDS)));
     }
 
     if (updateDescription.containsKey(TRUNCATED_ARRAYS)
@@ -154,8 +141,8 @@ final class OperationHelper {
       if (!removedField.isString()) {
         throw new DataException(
             format(
-                "Unexpected value type in %s, expected a string but found `%s`: %s",
-                REMOVED_FIELDS, removedField, updateDescription.toJson()));
+                "Unexpected value type in %s, expected an string but found `%s`",
+                REMOVED_FIELDS, removedField));
       }
       unsetDocument.append(removedField.asString().getValue(), EMPTY_STRING);
     }

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/OperationHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/OperationHelper.java
@@ -118,20 +118,18 @@ final class OperationHelper {
         && !updateDescription.get(TRUNCATED_ARRAYS).isArray()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expected an array but found `%s`: %s",
+              "Unexpected %s field type, expected an array but found `%s`",
               TRUNCATED_ARRAYS,
-              updateDescription.get(TRUNCATED_ARRAYS),
-              updateDescription.toJson()));
+              updateDescription.get(TRUNCATED_ARRAYS)));
     }
 
     if (updateDescription.containsKey(DISAMBIGUATED_PATHS)
         && !updateDescription.get(DISAMBIGUATED_PATHS).isDocument()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expected an array but found `%s`: %s",
+              "Unexpected %s field type, expected an array but found `%s`",
               DISAMBIGUATED_PATHS,
-              updateDescription.get(DISAMBIGUATED_PATHS),
-              updateDescription.toJson()));
+              updateDescription.get(DISAMBIGUATED_PATHS)));
     }
 
     BsonDocument updatedFields = updateDescription.getDocument(UPDATED_FIELDS);

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/Update.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/Update.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import org.bson.BsonDocument;
 
 import com.mongodb.client.model.ReplaceOneModel;
+import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.UpdateOneModel;
 import com.mongodb.client.model.WriteModel;
 
@@ -50,7 +51,8 @@ public class Update implements CdcOperation {
     BsonDocument documentKey = getDocumentKey(changeStreamDocument);
     if (hasFullDocument(changeStreamDocument)) {
       LOGGER.debug("The full Document available, creating a replace operation.");
-      return new ReplaceOneModel<>(documentKey, getFullDocument(changeStreamDocument));
+      return new ReplaceOneModel<>(
+          documentKey, getFullDocument(changeStreamDocument), new ReplaceOptions().upsert(true));
     }
 
     LOGGER.debug("No full document field available, creating update operation.");

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/qlik/rdbms/RdbmsHandler.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/qlik/rdbms/RdbmsHandler.java
@@ -17,7 +17,6 @@
 package com.mongodb.kafka.connect.sink.cdc.qlik.rdbms;
 
 import static com.mongodb.kafka.connect.sink.cdc.qlik.rdbms.operations.OperationHelper.DEFAULT_OPERATIONS;
-import static java.lang.String.format;
 
 import java.util.Map;
 import java.util.Optional;
@@ -71,12 +70,7 @@ public class RdbmsHandler extends QlikCdcHandler {
     OperationType operationType = OperationHelper.getOperationType(valueDocument);
     CdcOperation cdcOperation =
         getCdcOperation(operationType)
-            .orElseThrow(
-                () ->
-                    new DataException(
-                        format(
-                            "Unable to determine the CDC operation from: %s",
-                            valueDocument.toJson())));
+            .orElseThrow(() -> new DataException("Unable to determine the CDC operation"));
 
     return Optional.ofNullable(cdcOperation.perform(new SinkDocument(keyDocument, valueDocument)));
   }

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/qlik/rdbms/operations/OperationHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/qlik/rdbms/operations/OperationHelper.java
@@ -83,8 +83,7 @@ public final class OperationHelper {
     }
 
     if (!operation.isString()) {
-      throw new DataException(
-          format("Error: Could not determine the CDC operation type. %s", valueDocument.toJson()));
+      throw new DataException("Error: Could not determine the CDC operation type.");
     }
 
     return OperationType.fromString(operation.asString().getValue());
@@ -107,9 +106,7 @@ public final class OperationHelper {
                 });
     if (filter.isEmpty()) {
       throw new DataException(
-          format(
-              "Error: Value Document does not contain the expected data, cannot create filter: %s.",
-              valueDocument.toJson()));
+          "Error: Value Document does not contain the expected data, cannot create filter.");
     }
     return filter;
   }
@@ -128,9 +125,7 @@ public final class OperationHelper {
                 });
     if (filter.isEmpty()) {
       throw new DataException(
-          format(
-              "Error: Value Document does not contain the expected data, cannot create filter: %s.",
-              valueDocument.toJson()));
+          "Error: Value Document does not contain the expected data, cannot create filter.");
     }
     return filter;
   }
@@ -157,9 +152,7 @@ public final class OperationHelper {
 
     if (afterDocument.isEmpty()) {
       throw new DataException(
-          format(
-              "Error: Value Document does not contain the expected data, cannot create filter: %s.",
-              valueDocument.toJson()));
+          "Error: Value Document does not contain the expected data, cannot create filter.");
     }
 
     BsonDocument updates = new BsonDocument();
@@ -205,9 +198,7 @@ public final class OperationHelper {
 
       if (!fieldValue.isDocument()) {
         throw new DataException(
-            format(
-                "Error: Value document contains a '%s' that is not a document: %s",
-                fieldName, original));
+            format("Error: Value document contains a '%s' that is not a document", fieldName));
       }
       return fieldValue.asDocument();
     }

--- a/src/main/java/com/mongodb/kafka/connect/sink/converter/LazyBsonDocument.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/converter/LazyBsonDocument.java
@@ -161,8 +161,9 @@ public class LazyBsonDocument extends BsonDocument {
           } catch (Exception e) {
             throw new DataException(
                 format(
-                    "Could not convert key %s into a BsonDocument.",
-                    unambiguousToString(record.key())),
+                    "Could not convert key in topic:%s at partition:%s offset:%s into a "
+                        + "BsonDocument",
+                    record.topic(), record.kafkaPartition(), record.kafkaOffset()),
                 e);
           }
           break;
@@ -172,8 +173,9 @@ public class LazyBsonDocument extends BsonDocument {
           } catch (Exception e) {
             throw new DataException(
                 format(
-                    "Could not convert value %s into a BsonDocument.",
-                    unambiguousToString(record.value())),
+                    "Could not convert value in topic:%s at partition:%s offset:%s into a "
+                        + "BsonDocument.",
+                    record.topic(), record.kafkaPartition(), record.kafkaOffset()),
                 e);
           }
           break;

--- a/src/main/java/com/mongodb/kafka/connect/sink/converter/SinkConverter.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/converter/SinkConverter.java
@@ -39,7 +39,11 @@ public class SinkConverter {
   private static final RecordConverter BYTE_ARRAY_RECORD_CONVERTER = new ByteArrayRecordConverter();
 
   public SinkDocument convert(final SinkRecord record) {
-    LOGGER.debug("record: {}", record);
+    LOGGER.debug(
+        "record in topic:{} at partition:{}, offset:{}",
+        record.topic(),
+        record.kafkaPartition(),
+        record.kafkaOffset());
 
     BsonDocument keyDoc = null;
     if (record.key() != null) {

--- a/src/main/java/com/mongodb/kafka/connect/sink/namespace/mapping/FieldPathNamespaceMapper.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/namespace/mapping/FieldPathNamespaceMapper.java
@@ -133,22 +133,25 @@ public class FieldPathNamespaceMapper implements NamespaceMapper {
           optionalData.orElseThrow(
               () ->
                   new DataException(
-                      format("Invalid %s document: %s", isKey ? "key" : "value", sinkRecord)));
+                      format(
+                          "Invalid %s document in topic:%s at partition:%s offset:%s",
+                          isKey ? "key" : "value",
+                          sinkRecord.topic(),
+                          sinkRecord.kafkaPartition(),
+                          sinkRecord.kafkaOffset())));
 
       Optional<BsonValue> optionalFieldValue = fieldLookup(path, data);
       if (continueProcessing(optionalFieldValue.isPresent())) {
         BsonValue fieldValue =
             optionalFieldValue.orElseThrow(
-                () ->
-                    new DataException(
-                        format("Missing document path '%s': %s", path, data.toJson())));
+                () -> new DataException(format("Missing document path '%s'", path)));
 
         if (continueProcessing(fieldValue.isString())) {
           if (!fieldValue.isString()) {
             throw new DataException(
                 format(
-                    "Invalid type for %s field path '%s', expected a String: %s",
-                    fieldValue.getBsonType(), path, data.toJson()));
+                    "Invalid type for %s field path '%s', expected a String",
+                    fieldValue.getBsonType(), path));
           }
 
           return fieldValue.asString().getValue();

--- a/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/WriteModelStrategyHelper.java
@@ -56,7 +56,7 @@ public final class WriteModelStrategyHelper {
       return config
           .getDeleteWriteModelStrategy()
           .map(s -> s.createWriteModel(sinkDocument))
-          .orElseThrow(() -> new DataException("Could not create write model"));
+          .orElse(null);
     } catch (Exception e) {
       throw new DataException("Could not create write model", e);
     }

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoCopyDataManager.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoCopyDataManager.java
@@ -17,6 +17,7 @@ package com.mongodb.kafka.connect.source;
 
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COLLECTION_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.DATABASE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.REGEX_TIMEOUT_MS;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
@@ -30,8 +31,9 @@ import java.util.Optional;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import org.apache.kafka.connect.errors.ConnectException;
@@ -44,6 +46,7 @@ import org.bson.BsonType;
 import org.bson.RawBsonDocument;
 import org.bson.conversions.Bson;
 
+import com.github.jcustenborder.kafka.connect.utils.RegexUtils;
 import com.mongodb.MongoNamespace;
 import com.mongodb.client.MongoClient;
 
@@ -176,9 +179,22 @@ class MongoCopyDataManager implements AutoCloseable {
     }
 
     if (!namespacesRegex.isEmpty()) {
-      Predicate<String> predicate = Pattern.compile(namespacesRegex).asPredicate();
+      Pattern pattern = Pattern.compile(namespacesRegex);
+      long regexTimeout = sourceConfig.getLong(REGEX_TIMEOUT_MS);
       namespaces =
-          namespaces.stream().filter(n -> predicate.test(n.getFullName())).collect(toList());
+          namespaces.stream().filter(n -> {
+            try {
+              return RegexUtils.find(pattern, n.getFullName(), regexTimeout);
+            } catch (TimeoutException e) {
+              throw new ConnectException(
+                  "Regex replacement operation timed out after " + regexTimeout + "ms", e);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+              throw new ConnectException("Thread was interrupted during regex replacement", e);
+            } catch (ExecutionException e) {
+              throw new ConnectException("Error during regex replacement", e);
+            }
+          }).collect(toList());
     }
 
     return namespaces;

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoCopyDataManager.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoCopyDataManager.java
@@ -18,6 +18,7 @@ package com.mongodb.kafka.connect.source;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COLLECTION_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.DATABASE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.REGEX_TIMEOUT_MS;
+import static com.mongodb.kafka.connect.source.MongoSourceTask.TASK_ID_ZERO;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
@@ -36,6 +37,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
+import org.apache.kafka.common.utils.ThreadUtils;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,6 +71,7 @@ class MongoCopyDataManager implements AutoCloseable {
   private static final String NAMESPACE_FIELD = "ns";
   static final String ALT_NAMESPACE_FIELD = "__";
   private static final byte[] NAMESPACE_BYTES = NAMESPACE_FIELD.getBytes(StandardCharsets.UTF_8);
+  private static final String NAME = "name";
 
   private static final String PIPELINE_TEMPLATE =
       format(
@@ -106,9 +109,13 @@ class MongoCopyDataManager implements AutoCloseable {
     namespacesToCopy = new AtomicInteger(namespaces.size());
     CopyExistingConfig copyConfig = sourceConfig.getStartupConfig().copyExistingConfig();
     queue = new ArrayBlockingQueue<>(copyConfig.queueSize());
+    String connectorName = sourceConfig.originalsStrings().get(NAME);
+    String threadNamePattern =
+        connectorName + "-" + TASK_ID_ZERO + "-mongo-copy-data-manager-executor-%d";
     executor =
         Executors.newFixedThreadPool(
-            Math.max(1, Math.min(namespaces.size(), copyConfig.maxThreads())));
+            Math.max(1, Math.min(namespaces.size(), copyConfig.maxThreads())),
+            ThreadUtils.createThreadFactory(threadNamePattern, false));
     namespaces.forEach(n -> executor.submit(() -> copyDataFrom(n)));
   }
 

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -293,7 +293,7 @@ public class MongoSourceConfig extends AbstractConfig {
           PUBLISH_FULL_DOCUMENT_ONLY_TOMBSTONE_ON_DELETE_DEFAULT);
 
   public static final String DOCUMENT_KEY_AS_KEY_CONFIG = "change.stream.document.key.as.key";
-  private static final boolean DOCUMENT_KEY_AS_KEY_DEFAULT = true;
+  private static final boolean DOCUMENT_KEY_AS_KEY_DEFAULT = false;
   private static final String DOCUMENT_KEY_AS_KEY_DISPLAY =
       "Use the `documentKey` for the source record key";
   private static final String DOCUMENT_KEY_AS_KEY_DOC =
@@ -463,6 +463,14 @@ public class MongoSourceConfig extends AbstractConfig {
           + "\nIt is an equivalent replacement for the deprecated 'copy.existing.namespace.regex'.";
   static final String STARTUP_MODE_COPY_EXISTING_NAMESPACE_REGEX_DEFAULT = EMPTY_STRING;
 
+  public static final String REGEX_TIMEOUT_MS = "regex.timeout.ms";
+  public static final long REGEX_TIMEOUT_MS_DEFAULT = 100L;
+  private static final String REGEX_TIMEOUT_MS_DOC =
+      "Timeout in milliseconds for any regex operation. This controls how long the connector will "
+          + "wait for regex pattern compilation, matching, replacement, or any other regex-related "
+          + "operation to complete before timing out.";
+  private static final String REGEX_TIMEOUT_MS_DISPLAY = "Regex Timeout (ms)";
+
   static final String STARTUP_MODE_COPY_EXISTING_ALLOW_DISK_USE_CONFIG =
       "startup.mode.copy.existing.allow.disk.use";
   private static final String STARTUP_MODE_COPY_EXISTING_ALLOW_DISK_USE_DISPLAY =
@@ -548,6 +556,16 @@ public class MongoSourceConfig extends AbstractConfig {
   public static final String OVERRIDE_ERRORS_TOLERANCE_CONFIG = "mongo.errors.tolerance";
   public static final String OVERRIDE_ERRORS_TOLERANCE_DOC =
       "Use this property if you would like to configure the connector's error handling behavior differently from the Connect framework's.";
+
+  public static final String REMOVE_FIELD_ON_SCHEMA_MISMATCH_CONFIG = "remove.field.on.schema.mismatch";
+  public static final boolean REMOVE_FIELD_ON_SCHEMA_MISMATCH_DEFAULT = true;
+  private static final String REMOVE_FIELD_ON_SCHEMA_MISMATCH_DOC =
+      "If true, remove fields from the document that are not present in the schema. "
+          + "Otherwise, throw an error or send the documents to the DLQ depending on the value of "
+          + ERRORS_TOLERANCE_CONFIG
+          + " being set to ALL or NONE respectively.";
+  private static final String REMOVE_FIELD_ON_SCHEMA_MISMATCH_DISPLAY =
+      "Remove Field on Schema Mismatch";
 
   public static final String ERRORS_LOG_ENABLE_CONFIG = "errors.log.enable";
   public static final String ERRORS_LOG_ENABLE_DISPLAY = "Log Errors";
@@ -1381,6 +1399,18 @@ public class MongoSourceConfig extends AbstractConfig {
         STARTUP_MODE_COPY_EXISTING_NAMESPACE_REGEX_DISPLAY);
 
     configDef.define(
+        REGEX_TIMEOUT_MS,
+        ConfigDef.Type.LONG,
+        REGEX_TIMEOUT_MS_DEFAULT,
+        ConfigDef.Range.atLeast(1),
+        ConfigDef.Importance.LOW,
+        REGEX_TIMEOUT_MS_DOC,
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.SHORT,
+        REGEX_TIMEOUT_MS_DISPLAY);
+
+    configDef.define(
         STARTUP_MODE_COPY_EXISTING_ALLOW_DISK_USE_CONFIG,
         Type.BOOLEAN,
         STARTUP_MODE_COPY_EXISTING_ALLOW_DISK_USE_DEFAULT,
@@ -1486,6 +1516,18 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.SHORT,
         ERRORS_TOLERANCE_DISPLAY);
+
+    configDef.define(
+        REMOVE_FIELD_ON_SCHEMA_MISMATCH_CONFIG,
+        Type.BOOLEAN,
+        REMOVE_FIELD_ON_SCHEMA_MISMATCH_DEFAULT,
+        Importance.MEDIUM,
+        REMOVE_FIELD_ON_SCHEMA_MISMATCH_DOC,
+        group,
+        ++orderInGroup,
+        Width.SHORT,
+        REMOVE_FIELD_ON_SCHEMA_MISMATCH_DISPLAY
+    );
 
     configDef.define(
         ERRORS_LOG_ENABLE_CONFIG,

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -94,6 +94,11 @@ public final class MongoSourceTask extends SourceTask {
   private static final String NS_KEY = "ns";
   private static final int UNKNOWN_FIELD_ERROR = 40415;
   private static final int FAILED_TO_PARSE_ERROR = 9;
+  /**
+   * Since this is a single task connector, directly having task ID as "0" is safe.
+   * This should be passed from MongoSourceConnector.taskConfigs in case of multiple tasks.
+   */
+  public static final String TASK_ID_ZERO = "0";
 
   private StartedMongoSourceTask startedTask;
 

--- a/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
@@ -358,6 +358,7 @@ final class StartedMongoSourceTask implements AutoCloseable {
                 null,
                 headers));
       }
+      LOGGER.debug("Error in creating source record for the topic: {} and offset: {}", topicName, sourceOffset);
       throw new DataException(errorMessage.get(), e);
     }
   }

--- a/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/StartedMongoSourceTask.java
@@ -27,6 +27,7 @@ import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_AWAIT_TIME
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_MAX_BATCH_SIZE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.PUBLISH_FULL_DOCUMENT_ONLY_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.PUBLISH_FULL_DOCUMENT_ONLY_TOMBSTONE_ON_DELETE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.REMOVE_FIELD_ON_SCHEMA_MISMATCH_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.StartupConfig.StartupMode.COPY_EXISTING;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.StartupConfig.StartupMode.TIMESTAMP;
 import static com.mongodb.kafka.connect.source.MongoSourceTask.COPY_KEY;
@@ -56,6 +57,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.utils.Time;
@@ -63,6 +66,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTaskContext;
 
@@ -75,6 +79,7 @@ import org.bson.RawBsonDocument;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoException;
+import com.mongodb.MongoQueryException;
 import com.mongodb.client.ChangeStreamIterable;
 import com.mongodb.client.MongoChangeStreamCursor;
 import com.mongodb.client.MongoClient;
@@ -235,8 +240,7 @@ final class StartedMongoSourceTask implements AutoCloseable {
 
       String topicName = topicMapper.getTopic(changeStreamDocument);
       if (topicName.isEmpty()) {
-        LOGGER.warn(
-            "No topic set. Could not publish the message: {}", changeStreamDocument.toJson());
+        LOGGER.warn("No topic set. Could not publish the message.");
       } else {
 
         Optional<BsonDocument> valueDocument = Optional.empty();
@@ -255,7 +259,7 @@ final class StartedMongoSourceTask implements AutoCloseable {
 
         if (valueDocument.isPresent() || isTombstoneEvent) {
           BsonDocument valueDoc = valueDocument.orElse(new BsonDocument());
-          LOGGER.trace("Adding {} to {}: {}", valueDoc, topicName, sourceOffset);
+          LOGGER.trace("Adding document (hash) {} to {}: {}", valueDoc.hashCode(), topicName, sourceOffset);
 
           if (valueDoc instanceof RawBsonDocument) {
             int sizeBytes = ((RawBsonDocument) valueDoc).getByteBuffer().limit();
@@ -310,6 +314,9 @@ final class StartedMongoSourceTask implements AutoCloseable {
       @Nullable final BsonDocument valueDocument) {
 
     try {
+      if (!sourceConfig.getBoolean(REMOVE_FIELD_ON_SCHEMA_MISMATCH_CONFIG)) {
+        valueSchemaAndValueProducer.checkForExtraFields(valueDocument);
+      }
       SchemaAndValue keySchemaAndValue = keySchemaAndValueProducer.get(keyDocument);
       SchemaAndValue valueSchemaAndValue = valueSchemaAndValueProducer.get(valueDocument);
       return Optional.of(
@@ -322,13 +329,7 @@ final class StartedMongoSourceTask implements AutoCloseable {
               valueSchemaAndValue.schema(),
               valueSchemaAndValue.value()));
     } catch (Exception e) {
-      Supplier<String> errorMessage =
-          () ->
-              format(
-                  "%s : Exception creating Source record for: Key=%s Value=%s",
-                  e.getMessage(),
-                  keyDocument == null ? "" : keyDocument.toJson(),
-                  valueDocument == null ? "" : valueDocument.toJson());
+      Supplier<String> errorMessage = () -> "Exception creating Source record";
       if (sourceConfig.logErrors()) {
         LOGGER.error(errorMessage.get(), e);
       }
@@ -336,15 +337,26 @@ final class StartedMongoSourceTask implements AutoCloseable {
         if (sourceConfig.getDlqTopic().isEmpty()) {
           return Optional.empty();
         }
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("error_message", e.getMessage() != null ? e.getMessage() : "Unknown error occurred");
+        String fullStackTrace = Stream.of(e.getStackTrace())
+                .map(StackTraceElement::toString)
+                .collect(Collectors.joining(System.lineSeparator()));
+
+        String truncatedStackTrace = fullStackTrace.substring(0, Math.min(400, fullStackTrace.length()));
+        headers.addString("truncated_stacktrace", truncatedStackTrace);
         return Optional.of(
             new SourceRecord(
                 partitionMap,
                 sourceOffset,
                 sourceConfig.getDlqTopic(),
+                null,
                 Schema.STRING_SCHEMA,
                 keyDocument == null ? "" : keyDocument.toJson(),
                 Schema.STRING_SCHEMA,
-                valueDocument == null ? "" : valueDocument.toJson()));
+                valueDocument == null ? "" : valueDocument.toJson(),
+                null,
+                headers));
       }
       throw new DataException(errorMessage.get(), e);
     }
@@ -496,6 +508,8 @@ final class StartedMongoSourceTask implements AutoCloseable {
         if (changeStreamNotValid(e)) {
           throw new ConnectException(
               "ResumeToken not found. Cannot create a change stream cursor", e);
+        } else {
+          throw new ConnectException("Failed to resume change stream", e);
         }
       }
       return null;
@@ -620,10 +634,11 @@ final class StartedMongoSourceTask implements AutoCloseable {
                 "An exception occurred when trying to get the next item from the Change Stream", e);
           }
         } else {
-          throw new ConnectException(
-              "An exception occurred when trying to get the next item from the Change Stream: "
-                  + e.getMessage(),
-              e);
+          LOGGER.error(
+              "An exception occurred when trying to get the next item from the Change Stream", e);
+          if (e instanceof MongoQueryException && ((MongoQueryException) e).getErrorCode() == 286) {
+            throw new ConnectException("Failed to resume change stream", e);
+          }
         }
       }
     } catch (Exception e) {

--- a/src/main/java/com/mongodb/kafka/connect/source/producer/AvroSchemaAndValueProducer.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/producer/AvroSchemaAndValueProducer.java
@@ -38,4 +38,9 @@ final class AvroSchemaAndValueProducer implements SchemaAndValueProducer {
   public SchemaAndValue get(final BsonDocument changeStreamDocument) {
     return bsonValueToSchemaAndValue.toSchemaAndValue(schema, changeStreamDocument);
   }
+
+  @Override
+  public void checkForExtraFields(final BsonDocument changeStreamDocument) {
+    bsonValueToSchemaAndValue.checkForExtraFields(schema, changeStreamDocument);
+  }
 }

--- a/src/main/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducer.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducer.java
@@ -22,4 +22,7 @@ import org.bson.BsonDocument;
 
 public interface SchemaAndValueProducer {
   SchemaAndValue get(BsonDocument changeStreamDocument);
+  default void checkForExtraFields(final BsonDocument changeStreamDocument) {
+    // no-op
+  }
 }

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValue.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValue.java
@@ -60,6 +60,7 @@ import org.bson.codecs.Codec;
 import org.bson.codecs.EncoderContext;
 import org.bson.io.BasicOutputBuffer;
 import org.bson.json.JsonWriterSettings;
+import org.bson.BsonArray;
 
 public class BsonValueToSchemaAndValue {
   private static final Codec<BsonValue> BSON_VALUE_CODEC = new BsonValueCodec();
@@ -287,6 +288,38 @@ public class BsonValueToSchemaAndValue {
     return new SchemaAndValue(schema, structValue);
   }
 
+  public void checkForExtraFields(final Schema schema, final BsonValue bsonValue) {
+    if (schema.isOptional() && bsonValue.isNull()) {
+      return;
+    }
+    if (schema.type() == Type.STRUCT && bsonValue.isDocument()) {
+      BsonDocument doc = bsonValue.asDocument();
+      doc.forEach(
+          (key, value) -> {
+            Field field = schema.field(key);
+            if (field == null) {
+              throw extraFieldException(key);
+            }
+            checkForExtraFields(field.schema(), value);
+          }
+      );
+    } else if (schema.type() == Type.ARRAY && bsonValue.isArray()) {
+      BsonArray array = bsonValue.asArray();
+      array.forEach(
+          value -> {
+            checkForExtraFields(schema.valueSchema(), value);
+          }
+      );
+    } else if (schema.type() == Type.MAP && bsonValue.isDocument()) {
+      BsonDocument doc = bsonValue.asDocument();
+      doc.forEach(
+          (key, value) -> {
+            checkForExtraFields(schema.valueSchema(), value);
+          }
+      );
+    }
+  }
+
   private SchemaAndValue booleanToSchemaAndValue(final Schema schema, final BsonValue bsonValue) {
     if (!bsonValue.isBoolean()) {
       throw unexpectedBsonValueType(Schema.Type.BOOLEAN, bsonValue);
@@ -310,7 +343,10 @@ public class BsonValueToSchemaAndValue {
   }
 
   private DataException missingFieldException(final Field field, final BsonDocument value) {
-    return new DataException(
-        format("Missing field '%s' in: '%s'", field.name(), value.toJson(jsonWriterSettings)));
+    return new DataException(format("Missing field '%s'", field.name()));
+  }
+
+  private DataException extraFieldException(final String key) {
+    return new DataException(format("The field '%s' is not defined in the Schema.", key));
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValue.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonValueToSchemaAndValue.java
@@ -61,10 +61,13 @@ import org.bson.codecs.EncoderContext;
 import org.bson.io.BasicOutputBuffer;
 import org.bson.json.JsonWriterSettings;
 import org.bson.BsonArray;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BsonValueToSchemaAndValue {
   private static final Codec<BsonValue> BSON_VALUE_CODEC = new BsonValueCodec();
   private final JsonWriterSettings jsonWriterSettings;
+  private static final Logger LOGGER = LoggerFactory.getLogger(BsonValueToSchemaAndValue.class);
 
   public BsonValueToSchemaAndValue(final JsonWriterSettings jsonWriterSettings) {
     this.jsonWriterSettings = jsonWriterSettings;
@@ -75,36 +78,41 @@ public class BsonValueToSchemaAndValue {
     if (schema.isOptional() && bsonValue.isNull()) {
       return new SchemaAndValue(schema, null);
     }
-
-    switch (schema.type()) {
-      case INT8:
-      case INT16:
-      case INT32:
-      case INT64:
-      case FLOAT32:
-      case FLOAT64:
-        schemaAndValue = numberToSchemaAndValue(schema, bsonValue);
-        break;
-      case BOOLEAN:
-        schemaAndValue = booleanToSchemaAndValue(schema, bsonValue);
-        break;
-      case STRING:
-        schemaAndValue = stringToSchemaAndValue(schema, bsonValue);
-        break;
-      case BYTES:
-        schemaAndValue = bytesToSchemaAndValue(schema, bsonValue);
-        break;
-      case ARRAY:
-        schemaAndValue = arrayToSchemaAndValue(schema, bsonValue);
-        break;
-      case MAP:
-        schemaAndValue = mapToSchemaAndValue(schema, bsonValue);
-        break;
-      case STRUCT:
-        schemaAndValue = recordToSchemaAndValue(schema, bsonValue);
-        break;
-      default:
-        throw unsupportedSchemaType(schema);
+    try {
+      switch (schema.type()) {
+        case INT8:
+        case INT16:
+        case INT32:
+        case INT64:
+        case FLOAT32:
+        case FLOAT64:
+          schemaAndValue = numberToSchemaAndValue(schema, bsonValue);
+          break;
+        case BOOLEAN:
+          schemaAndValue = booleanToSchemaAndValue(schema, bsonValue);
+          break;
+        case STRING:
+          schemaAndValue = stringToSchemaAndValue(schema, bsonValue);
+          break;
+        case BYTES:
+          schemaAndValue = bytesToSchemaAndValue(schema, bsonValue);
+          break;
+        case ARRAY:
+          schemaAndValue = arrayToSchemaAndValue(schema, bsonValue);
+          break;
+        case MAP:
+          schemaAndValue = mapToSchemaAndValue(schema, bsonValue);
+          break;
+        case STRUCT:
+          schemaAndValue = recordToSchemaAndValue(schema, bsonValue);
+          break;
+        default:
+          throw unsupportedSchemaType(schema);
+      }
+    }
+    catch (DataException e) {
+      LOGGER.debug("Error while converting bson value {} to schema {}", bsonValue, schema);
+      throw e;
     }
     return schemaAndValue;
   }

--- a/src/main/java/com/mongodb/kafka/connect/util/ConnectionValidator.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/ConnectionValidator.java
@@ -94,45 +94,52 @@ public final class ConnectionValidator {
             customCredentialProvider.getCustomCredential(connectorProperties.originals()));
       }
       setServerApi(mongoClientSettingsBuilder, config);
+      final MongoClientSettings mongoClientSettings;
+      try {
+        mongoClientSettings =
+            mongoClientSettingsBuilder
+                .applyToClusterSettings(
+                    b ->
+                        b.addClusterListener(
+                            new ClusterListener() {
+                              @Override
+                              public void clusterOpening(final ClusterOpeningEvent event) {}
 
-      MongoClientSettings mongoClientSettings =
-          mongoClientSettingsBuilder
-              .applyToClusterSettings(
-                  b ->
-                      b.addClusterListener(
-                          new ClusterListener() {
-                            @Override
-                            public void clusterOpening(final ClusterOpeningEvent event) {}
+                              @Override
+                              public void clusterClosed(final ClusterClosedEvent event) {}
 
-                            @Override
-                            public void clusterClosed(final ClusterClosedEvent event) {}
-
-                            @Override // Different database than has permissions for
-                            public void clusterDescriptionChanged(
-                                final ClusterDescriptionChangedEvent event) {
-                              ReadPreference readPreference =
-                                  connectionString.getReadPreference() != null
-                                      ? connectionString.getReadPreference()
-                                      : ReadPreference.primaryPreferred();
-                              if (!connected.get()
-                                  && event.getNewDescription().hasReadableServer(readPreference)) {
-                                connected.set(true);
-                                latch.countDown();
+                              @Override // Different database than has permissions for
+                              public void clusterDescriptionChanged(
+                                  final ClusterDescriptionChangedEvent event) {
+                                ReadPreference readPreference =
+                                    connectionString.getReadPreference() != null
+                                        ? connectionString.getReadPreference()
+                                        : ReadPreference.primaryPreferred();
+                                if (!connected.get()
+                                    && event
+                                        .getNewDescription()
+                                        .hasReadableServer(readPreference)) {
+                                  connected.set(true);
+                                  latch.countDown();
+                                }
                               }
-                            }
-                          }))
-              .applyToSslSettings(sslBuilder -> setupSsl(sslBuilder, connectorProperties))
-              .build();
+                            }))
+                .applyToSslSettings(sslBuilder -> setupSsl(sslBuilder, connectorProperties))
+                .build();
+      } catch (IllegalArgumentException exception) {
+        configValue.addErrorMessage(exception.getMessage());
+        return Optional.empty();
+      }
 
       long latchTimeout =
           mongoClientSettings.getSocketSettings().getConnectTimeout(TimeUnit.MILLISECONDS) + 500;
       MongoClient mongoClient = MongoClients.create(mongoClientSettings);
 
       try {
-        if (!latch.await(latchTimeout, TimeUnit.MILLISECONDS)) {
-          configValue.addErrorMessage("Unable to connect to the server.");
-          mongoClient.close();
-        }
+          if (!latch.await(latchTimeout, TimeUnit.MILLISECONDS)) {
+            configValue.addErrorMessage("Unable to connect to the server.");
+            mongoClient.close();
+          }
       } catch (InterruptedException e) {
         mongoClient.close();
         throw new ConnectException(e);

--- a/src/main/java/com/mongodb/kafka/connect/util/Validators.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/Validators.java
@@ -37,8 +37,14 @@ import org.apache.kafka.common.config.types.Password;
 import org.slf4j.Logger;
 
 import com.mongodb.kafka.connect.util.config.BsonTimestampParser;
+import org.slf4j.LoggerFactory;
 
 public final class Validators {
+
+  private static String redactedUrl = "[REDACTED URL]";
+  private static final Logger LOGGER = LoggerFactory.getLogger(Validators.class);
+  private static String connectionUriErrorMessage = "Connection string is invalid. Please enter " +
+          "the valid connection.host, connection.user and connection.password and try again.";
 
   public interface ValidatorWithOperators extends ConfigDef.Validator {
     default ValidatorWithOperators or(final ValidatorWithOperators other) {
@@ -161,8 +167,11 @@ public final class Validators {
         ((name, value) -> {
           try {
             consumer.accept((String) value);
+          } catch (IllegalArgumentException e){
+            LOGGER.error(e.getMessage());
+            throw new ConfigException(name, redactedUrl, connectionUriErrorMessage);
           } catch (Exception e) {
-            throw new ConfigException(name, value, e.getMessage());
+            throw new ConfigException(name, redactedUrl, e.getMessage());
           }
         }));
   }

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordDataTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordDataTest.java
@@ -70,6 +70,9 @@ class MongoProcessedSinkRecordDataTest {
       new SinkRecord(
           TEST_TOPIC, 0, Schema.STRING_SCHEMA, "{_id: 1}", Schema.STRING_SCHEMA, VALUE_JSON, 1);
 
+  private static final SinkRecord TOMBSTONE_SINK_RECORD =
+      new SinkRecord(TEST_TOPIC, 0, Schema.STRING_SCHEMA, "{_id: 1}", null, null, 1);
+
   private static final SinkRecord INVALID_SINK_RECORD =
       new SinkRecord(TEST_TOPIC, 0, Schema.INT32_SCHEMA, 1, Schema.INT32_SCHEMA, 1, 1);
 
@@ -104,6 +107,16 @@ class MongoProcessedSinkRecordDataTest {
 
     assertEquals(new MongoNamespace("myDB.myColl"), processedData.getNamespace());
     assertWriteModel(processedData);
+  }
+
+  @Test
+  @DisplayName("test default processing tombstone record")
+  void testDefaultProcessingTombstone() {
+    MongoProcessedSinkRecordData processedData =
+        new MongoProcessedSinkRecordData(TOMBSTONE_SINK_RECORD, createSinkConfig());
+
+    assertEquals(new MongoNamespace("myDB.topic"), processedData.getNamespace());
+    assertNull(processedData.getWriteModel());
   }
 
   @Test

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
@@ -305,7 +305,7 @@ class MongoSinkConfigTest {
   void testTopicRegexWithOverridesReDOS() {
     String safeRegex = "(a+)+";
     String unsafeRegex = "(a+)+b";
-    
+
     // Create a string that will definitely cause a timeout with the unsafe regex,
     // but not with the safe regex
     // The string contains only 'a's but the unsafe regex requires a 'b' at the end

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
@@ -301,6 +301,44 @@ class MongoSinkConfigTest {
   }
 
   @Test
+  @DisplayName("test topic regex with overrides avoids CWE-1333 ReDOS")
+  void testTopicRegexWithOverridesReDOS() {
+    String safeRegex = "(a+)+";
+    String unsafeRegex = "(a+)+b";
+    
+    // Create a string that will definitely cause a timeout with the unsafe regex,
+    // but not with the safe regex
+    // The string contains only 'a's but the unsafe regex requires a 'b' at the end
+    // This will cause catastrophic backtracking.
+    // The length of topic must be greater than 100000 to cause a timeout.
+    StringBuilder input = new StringBuilder();
+    for (int i = 0; i < 100000; i++) {
+      input.append("a");
+    }
+    String topicOverride = input.toString();
+
+    MongoSinkConfig cfg =
+        createSinkConfig(
+            format(
+                "{'%s': '%s', '%s': 'otherDB', '%s': 'coll2'}",
+                TOPICS_REGEX_CONFIG,
+                safeRegex,
+                createOverrideKey(topicOverride, DATABASE_CONFIG),
+                createOverrideKey(topicOverride, COLLECTION_CONFIG)));
+    assertPattern("(a+)+", cfg.getTopicRegex().orElse(EMPTY_PATTERN));
+    assertEquals("otherDB", cfg.getMongoSinkTopicConfig(topicOverride).getString(DATABASE_CONFIG));
+    assertEquals("coll2", cfg.getMongoSinkTopicConfig(topicOverride).getString(COLLECTION_CONFIG));
+    ConfigException exception = assertThrows(
+        ConfigException.class,
+        () ->
+            createSinkConfig(
+                format(
+                    "{'%s': '%s', '%s': 'made up'}",
+                    TOPICS_REGEX_CONFIG, unsafeRegex, createOverrideKey(topicOverride, KEY_PROJECTION_TYPE_CONFIG))));
+    assertTrue(exception.getMessage().contains("Regex match operation timed out after "));
+  }
+
+  @Test
   @DisplayName("test K/V projection with invalid projection type")
   void testProjectionWithInvalidProjectionTypes() {
     assertAll(

--- a/src/test/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/UpdateTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/UpdateTest.java
@@ -18,7 +18,6 @@ package com.mongodb.kafka.connect.sink.cdc.mongodb.operations;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -79,9 +78,9 @@ class UpdateTest {
         "filter expected to be of type BsonDocument");
     assertEquals(CHANGE_EVENT.getDocument("documentKey"), writeModel.getFilter());
     assertEquals(CHANGE_EVENT.getDocument("fullDocument"), writeModel.getReplacement());
-    assertFalse(
+    assertTrue(
         writeModel.getReplaceOptions().isUpsert(),
-        "update replacement expected not to be in upsert mode");
+        "update replacement expected to be in upsert mode");
   }
 
   @Test

--- a/src/test/java/com/mongodb/kafka/connect/source/MongoCopyDataManagerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/MongoCopyDataManagerTest.java
@@ -73,6 +73,7 @@ import com.mongodb.Function;
 import com.mongodb.MongoNamespace;
 import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.MongoClient;
+import com.mongodb.client.ListCollectionNamesIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
@@ -280,7 +281,7 @@ class MongoCopyDataManagerTest {
     String template2 = createTemplate(2, "myDB", "coll2");
 
     when(mongoClient.getDatabase(TEST_DATABASE)).thenReturn(mongoDatabase);
-    when(mongoDatabase.listCollectionNames()).thenReturn(new MockMongoIterable<>("coll1", "coll2"));
+    when(mongoDatabase.listCollectionNames()).thenReturn(new MockListCollectionNamesIterable("coll1", "coll2"));
     when(mongoDatabase.getCollection("coll1", RawBsonDocument.class)).thenReturn(mongoCollection);
     when(mongoDatabase.getCollection("coll2", RawBsonDocument.class))
         .thenReturn(mongoCollectionAlt);
@@ -332,8 +333,8 @@ class MongoCopyDataManagerTest {
     when(mongoClient.listDatabaseNames()).thenReturn(new MockMongoIterable<>("db1", "db2"));
     when(mongoClient.getDatabase("db1")).thenReturn(mongoDatabase);
     when(mongoClient.getDatabase("db2")).thenReturn(mongoDatabaseAlt);
-    when(mongoDatabase.listCollectionNames()).thenReturn(new MockMongoIterable<>("coll1"));
-    when(mongoDatabaseAlt.listCollectionNames()).thenReturn(new MockMongoIterable<>("coll2"));
+    when(mongoDatabase.listCollectionNames()).thenReturn(new MockListCollectionNamesIterable("coll1"));
+    when(mongoDatabaseAlt.listCollectionNames()).thenReturn(new MockListCollectionNamesIterable("coll2"));
 
     when(mongoDatabase.getCollection("coll1", RawBsonDocument.class)).thenReturn(mongoCollection);
     when(mongoDatabaseAlt.getCollection("coll2", RawBsonDocument.class))
@@ -388,9 +389,9 @@ class MongoCopyDataManagerTest {
     when(mongoClient.getDatabase("db2")).thenReturn(mongoDatabaseAlt);
 
     when(mongoDatabase.listCollectionNames())
-        .thenReturn(new MockMongoIterable<>("coll1", "coll2", "coll3"));
+        .thenReturn(new MockListCollectionNamesIterable("coll1", "coll2", "coll3"));
     when(mongoDatabaseAlt.listCollectionNames())
-        .thenReturn(new MockMongoIterable<>("coll1", "coll2"));
+        .thenReturn(new MockListCollectionNamesIterable("coll1", "coll2"));
 
     assertAll(
         () -> {
@@ -641,6 +642,71 @@ class MongoCopyDataManagerTest {
     @Override
     public MongoIterable<T> batchSize(final int batchSize) {
       throw new UnsupportedOperationException("Unsupported operation");
+    }
+  }
+
+  private static final class MockListCollectionNamesIterable implements ListCollectionNamesIterable {
+
+    private final Collection<String> result;
+
+    private MockListCollectionNamesIterable(final String... result) {
+      this.result = asList(result);
+    }
+
+    @Override
+    public MongoCursor<String> iterator() {
+      throw new UnsupportedOperationException("Unsupported operation");
+    }
+
+    @Override
+    public MongoCursor<String> cursor() {
+      throw new UnsupportedOperationException("Unsupported operation");
+    }
+
+    @Override
+    public String first() {
+      return null;
+    }
+
+    @Override
+    public <U> MongoIterable<U> map(final Function<String, U> mapper) {
+      throw new UnsupportedOperationException("Unsupported operation");
+    }
+
+    @Override
+    public <A extends Collection<? super String>> A into(final A target) {
+      target.addAll(result);
+      return target;
+    }
+
+    @Override
+    public ListCollectionNamesIterable batchSize(final int batchSize) {
+      return this;
+    }
+
+    @Override
+    public ListCollectionNamesIterable maxTime(final long maxTime, final java.util.concurrent.TimeUnit timeUnit) {
+      return this;
+    }
+
+    @Override
+    public ListCollectionNamesIterable comment(final String comment) {
+      return this;
+    }
+
+    @Override
+    public ListCollectionNamesIterable comment(final org.bson.BsonValue comment) {
+      return this;
+    }
+
+    @Override
+    public ListCollectionNamesIterable authorizedCollections(final boolean authorizedCollections) {
+      return this;
+    }
+
+    @Override
+    public ListCollectionNamesIterable filter(final Bson filter) {
+      return this;
     }
   }
 }

--- a/src/test/java/com/mongodb/kafka/connect/source/MongoCopyDataManagerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/MongoCopyDataManagerTest.java
@@ -20,6 +20,7 @@ import static com.mongodb.kafka.connect.source.MongoSourceConfig.COLLECTION_CONF
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COPY_EXISTING_ALLOW_DISK_USE_DEFAULT;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.DATABASE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.PIPELINE_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.REGEX_TIMEOUT_MS;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.STARTUP_MODE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.STARTUP_MODE_COPY_EXISTING_ALLOW_DISK_USE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.STARTUP_MODE_COPY_EXISTING_NAMESPACE_REGEX_CONFIG;
@@ -36,6 +37,8 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -48,10 +51,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -477,6 +482,52 @@ class MongoCopyDataManagerTest {
       sleep();
       copyExistingDataManager.poll();
     }
+  }
+
+  @Test
+  public void testRegexReplacementWithTimeout() {
+    StringBuilder input = new StringBuilder();
+    for (int i = 0; i < 10000; i++) {
+      input.append("a");
+    }
+    String inputString = input.toString();
+
+    Map<String, String> props = new HashMap<>();
+    props.put(STARTUP_MODE_CONFIG, StartupMode.COPY_EXISTING.propertyValue());
+    props.put(DATABASE_CONFIG, inputString);
+    props.put(COLLECTION_CONFIG, inputString);
+    props.put(STARTUP_MODE_COPY_EXISTING_NAMESPACE_REGEX_CONFIG, "(([a.]+)+)Z");
+    props.put(REGEX_TIMEOUT_MS, "100");
+    MongoSourceConfig sourceConfig = createSourceConfig(props);
+
+    ConnectException exception = assertThrows(ConnectException.class,
+        () -> new MongoCopyDataManager(sourceConfig, mongoClient));
+    assertInstanceOf(TimeoutException.class, exception.getCause());
+  }
+
+  @Test
+  public void testRegexReplacementWithInterruption() throws InterruptedException {
+    StringBuilder input = new StringBuilder();
+    for (int i = 0; i < 10000; i++) {
+      input.append("a");
+    }
+    String inputString = input.toString();
+
+    Map<String, String> props = new HashMap<>();
+    props.put(STARTUP_MODE_CONFIG, StartupMode.COPY_EXISTING.propertyValue());
+    props.put(DATABASE_CONFIG, inputString);
+    props.put(COLLECTION_CONFIG, inputString);
+    props.put(STARTUP_MODE_COPY_EXISTING_NAMESPACE_REGEX_CONFIG, "(([a.]+)+)Z");
+    MongoSourceConfig sourceConfig = createSourceConfig(props);
+
+    Thread copyDataManagerThread = new Thread(() -> {
+      ConnectException e = assertThrows(ConnectException.class, () -> new MongoCopyDataManager(sourceConfig, mongoClient));
+      assertInstanceOf(InterruptedException.class, e.getCause(), "Expected InterruptedException as cause");
+      assertTrue(Thread.currentThread().isInterrupted(), "Thread should be interrupted");
+    });
+    copyDataManagerThread.start();
+    copyDataManagerThread.interrupt();
+    copyDataManagerThread.join(2000);
   }
 
   private void sleep(final int millis) {

--- a/src/test/java/com/mongodb/kafka/connect/source/MongoCopyDataManagerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/MongoCopyDataManagerTest.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -126,6 +127,51 @@ class MongoCopyDataManagerTest {
 
     List<Optional<BsonDocument>> expected = asList(createOutput(jsonTemplate), Optional.empty());
     assertEquals(expected, results);
+  }
+
+  @Test
+  @DisplayName("threads are named with connector and task prefix for copy-existing executor")
+  void testThreadNamesForCopyExistingExecutor() {
+    String connectorName = "MyConnector";
+    String taskId = "0";
+    String jsonTemplate = createTemplate(1);
+
+    when(mongoClient.getDatabase(TEST_DATABASE)).thenReturn(mongoDatabase);
+    when(mongoDatabase.getCollection(TEST_COLLECTION, RawBsonDocument.class))
+        .thenReturn(mongoCollection);
+    when(mongoCollection.aggregate(anyList())).thenReturn(aggregateIterable);
+    when(aggregateIterable.allowDiskUse(COPY_EXISTING_ALLOW_DISK_USE_DEFAULT))
+        .thenReturn(aggregateIterable);
+    doCallRealMethod().when(aggregateIterable).forEach(any(Consumer.class));
+    when(aggregateIterable.iterator()).thenReturn(cursor);
+
+    when(cursor.hasNext()).thenReturn(true, false);
+
+    AtomicReference<String> threadNameRef = new AtomicReference<>();
+    when(cursor.next())
+        .thenAnswer(
+            invocation -> {
+              threadNameRef.set(Thread.currentThread().getName());
+              return createInput(jsonTemplate);
+            });
+
+    Map<String, String> props = new HashMap<>();
+    props.put(STARTUP_MODE_CONFIG, StartupMode.COPY_EXISTING.propertyValue());
+    props.put(DATABASE_CONFIG, TEST_DATABASE);
+    props.put(COLLECTION_CONFIG, TEST_COLLECTION);
+    props.put("name", connectorName);
+
+    try (MongoCopyDataManager copyExistingDataManager =
+             new MongoCopyDataManager(new MongoSourceConfig(props), mongoClient)) {
+      sleep(300);
+      copyExistingDataManager.poll();
+    }
+
+    String expectedPrefix = connectorName + "-" + taskId + "-mongo-copy-data-manager-executor-";
+    assertTrue(
+        threadNameRef.get() != null && threadNameRef.get().startsWith(expectedPrefix),
+        () -> "Expected thread name to start with '"
+            + expectedPrefix + "' but was '" + threadNameRef.get() + "'");
   }
 
   @Test

--- a/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
@@ -28,6 +28,8 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.math.BigDecimal;
 import java.util.Base64;
@@ -41,6 +43,8 @@ import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.DataException;
+import org.bson.BsonInt32;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -149,6 +153,92 @@ public class SchemaAndValueProducerTest {
         new AvroSchemaAndValueProducer(DEFAULT_AVRO_VALUE_SCHEMA, EXTENDED_JSON_WRITER_SETTINGS);
     assertSchemaAndValueEquals(
         expectedExtendedValue, extendedJsonValueProducer.get(CHANGE_STREAM_DOCUMENT));
+  }
+
+  @Test
+  @DisplayName("test extra fields not in schema")
+  void testExtraFieldsNotInSchema() {
+    String complexJsonSchema = "{"
+        + "\"type\": \"record\","
+        + "\"name\": \"ComplexRecord\","
+        + "\"fields\": ["
+        + "  {"
+        + "    \"name\": \"nestedDocument\","
+        + "    \"type\": {"
+        + "      \"type\": \"record\","
+        + "      \"name\": \"NestedDocument\","
+        + "      \"fields\": ["
+        + "        {\"name\": \"field1\", \"type\": \"string\"},"
+        + "        {\"name\": \"field2\", \"type\": \"int\"}"
+        + "      ]"
+        + "    }"
+        + "  },"
+        + "  {"
+        + "    \"name\": \"arrayWithDocuments\","
+        + "    \"type\": {"
+        + "      \"type\": \"array\","
+        + "      \"items\": {"
+        + "        \"type\": \"record\","
+        + "        \"name\": \"ArrayItem\","
+        + "        \"fields\": ["
+        + "          {\"name\": \"itemField1\", \"type\": \"string\"},"
+        + "          {\"name\": \"itemField2\", \"type\": \"boolean\"}"
+        + "        ]"
+        + "      }"
+        + "    }"
+        + "  }"
+        + "]"
+        + "}";
+
+    String complexJsonValue = "{\n" +
+        "  \"nestedDocument\": {\n" +
+        "    \"field1\": \"example string\",\n" +
+        "    \"field2\": 123\n" +
+        "  },\n" +
+        "  \"arrayWithDocuments\": [\n" +
+        "    {\n" +
+        "      \"itemField1\": \"item1\",\n" +
+        "      \"itemField2\": true\n" +
+        "    },\n" +
+        "    {\n" +
+        "      \"itemField1\": \"item2\",\n" +
+        "      \"itemField2\": false\n" +
+        "    }\n" +
+        "  ]\n" +
+        "}";
+
+    BsonDocument fullDocument = BsonDocument.parse(complexJsonValue);
+
+    SchemaAndValueProducer inferSchemaAndValueProducer =
+        new InferSchemaAndValueProducer(SIMPLE_JSON_WRITER_SETTINGS);
+    assertDoesNotThrow(
+        () -> inferSchemaAndValueProducer.checkForExtraFields(fullDocument));
+
+    SchemaAndValueProducer avroSchemaAndValueProducer =
+        new AvroSchemaAndValueProducer(complexJsonSchema, SIMPLE_JSON_WRITER_SETTINGS);
+    assertDoesNotThrow(
+        () -> avroSchemaAndValueProducer.checkForExtraFields(fullDocument));
+
+    fullDocument.get("arrayWithDocuments").asArray().get(1).asDocument().append("extraField", new BsonInt32(1));
+    assertThrows(
+        DataException.class,
+        () -> avroSchemaAndValueProducer.checkForExtraFields(fullDocument));
+    fullDocument.get("arrayWithDocuments").asArray().get(1).asDocument().remove("extraField");
+
+    fullDocument.get("nestedDocument").asDocument().append("extraField", new BsonInt32(1));
+    assertThrows(
+        DataException.class,
+        () -> avroSchemaAndValueProducer.checkForExtraFields(fullDocument));
+    fullDocument.get("nestedDocument").asDocument().remove("extraField");
+
+    fullDocument.append("extraField", new BsonInt32(1));
+    assertThrows(
+        DataException.class,
+        () -> avroSchemaAndValueProducer.checkForExtraFields(fullDocument));
+    fullDocument.remove("extraField");
+
+    assertDoesNotThrow(
+        () -> avroSchemaAndValueProducer.checkForExtraFields(fullDocument));
   }
 
   @Test


### PR DESCRIPTION
Problem:
https://confluentinc.atlassian.net/browse/CC-38701
Upgrade mongo-kafka to v2.0.2

Solution:
The mongo-kafka fork branch was upgraded to 2.0.2. In this PR adding the cherry-picks which are not present in the forked repo to the upgraded branch.