### PR TITLE
CC-40290: Sem job for auto triggering tag creation

### DIFF
--- a/.semaphore/create-tag.yml
+++ b/.semaphore/create-tag.yml
@@ -15,6 +15,9 @@ blocks:
         - name: Create Tag
           commands:
             - checkout --use-cache
-            - if [ -n "$BRANCH_NAME" ]; then git checkout $BRANCH_NAME; fi
-            - ci-tools ci-update-version
-            - ci-tools ci-push-tag
+            - if [ -n "$BRANCH_NAME" ]; then git checkout "$BRANCH_NAME"; fi
+            - BRANCH=$(git rev-parse --abbrev-ref HEAD)
+            - COMMIT_ID=$(git rev-parse --short HEAD)
+            - TAG_NAME="rc-${BRANCH}-${COMMIT_ID}"
+            - git tag "$TAG_NAME"
+            - git push origin "$TAG_NAME"

--- a/.semaphore/create-tag.yml
+++ b/.semaphore/create-tag.yml
@@ -1,0 +1,20 @@
+version: v1.0
+name: create-mongo-kafka-tag
+agent:
+  machine:
+    type: s1-prod-ubuntu24-04-amd64-1
+
+execution_time_limit:
+  hours: 1
+
+blocks:
+  - name: Create Tag
+    dependencies: []
+    task:
+      jobs:
+        - name: Create Tag
+          commands:
+            - checkout --use-cache
+            - if [ -n "$BRANCH_NAME" ]; then git checkout $BRANCH_NAME; fi
+            - ci-tools ci-update-version
+            - ci-tools ci-push-tag

--- a/.semaphore/create-tag.yml
+++ b/.semaphore/create-tag.yml
@@ -18,6 +18,6 @@ blocks:
             - if [ -n "$BRANCH_NAME" ]; then git checkout "$BRANCH_NAME"; fi
             - BRANCH=$(git rev-parse --abbrev-ref HEAD)
             - COMMIT_ID=$(git rev-parse --short HEAD)
-            - TAG_NAME="rc-${BRANCH}-${COMMIT_ID}"
+            - TAG_NAME="{BRANCH}-rc-${COMMIT_ID}-cloud"
             - git tag "$TAG_NAME"
             - git push origin "$TAG_NAME"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,7 @@ plugins {
 }
 
 group = "org.mongodb.kafka"
-version = "2.0.2"
+version = property("version") as String
 description = "The official MongoDB Apache Kafka Connect Connector."
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
+version=2.0.2
 org.gradle.java.installations.auto-download=false
 org.gradle.java.installations.fromEnv=JDK8,JDK17
 org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xmx1G

--- a/service.yml
+++ b/service.yml
@@ -25,6 +25,6 @@ semaphore:
       parameters:
         - name: BRANCH_NAME
           required: true
-          description: 'Branch used to create a tag for CP-patched branches (for example 2.0.x, 1.14.x). Not intended for hotfix branches.'
+          description: 'Branch used to create a tag for CP-patched branches (for example v2.0.x, v1.14.x). Not intended for hotfix branches.'
 sonarqube:
   enable: true

--- a/service.yml
+++ b/service.yml
@@ -7,7 +7,6 @@ codeowners:
   enable: true
 semaphore:
   enable: true
-  pipeline_type: cp
   pipeline_enable: false
   cve_scan: true
   extra_deploy_args: "-Dcloud -Pjenkins"

--- a/service.yml
+++ b/service.yml
@@ -1,6 +1,6 @@
 name: mongo-kafka
 lang: java
-lang_version: "17"
+lang_version: 8
 git:
   enable: true
 codeowners:
@@ -8,13 +8,16 @@ codeowners:
 semaphore:
   enable: true
   pipeline_type: cp
+  pipeline_enable: false
+  cve_scan: true
+  extra_deploy_args: "-Dcloud -Pjenkins"
+  extra_build_args: "-Dcloud -Pjenkins"
   branches:
-    - master
-    - /^\d+\.\d+\.x$/
+    - /^v\d+\.\d+\.x$/
   promotions:
     - name: Create Tag
       pipeline_file: .semaphore/create-tag.yml
-      auto_promote_when: "result = 'passed' and branch =~ '^\\d+\\.\\d+\\.x$'"
+      auto_promote_when: "result = 'passed' and branch =~ '^v\\d+\\.\\d+\\.x$'"
   tasks:
     - name: create-mongo-kafka-tag
       branch: master
@@ -23,3 +26,5 @@ semaphore:
         - name: BRANCH_NAME
           required: true
           description: 'Branch used to create a tag for CP-patched branches (for example 2.0.x, 1.14.x). Not intended for hotfix branches.'
+sonarqube:
+  enable: true

--- a/service.yml
+++ b/service.yml
@@ -1,15 +1,25 @@
 name: mongo-kafka
 lang: java
-lang_version: 8
+lang_version: "17"
 git:
   enable: true
 codeowners:
   enable: true
 semaphore:
   enable: true
-  pipeline_enable: false
-  cve_scan: true
-  extra_deploy_args: "-Dcloud -Pjenkins"
-  extra_build_args: "-Dcloud -Pjenkins"
-sonarqube:
-  enable: true
+  pipeline_type: cp
+  branches:
+    - master
+    - /^\d+\.\d+\.x$/
+  promotions:
+    - name: Create Tag
+      pipeline_file: .semaphore/create-tag.yml
+      auto_promote_when: "result = 'passed' and branch =~ '^\\d+\\.\\d+\\.x$'"
+  tasks:
+    - name: create-mongo-kafka-tag
+      branch: master
+      pipeline_file: .semaphore/create-tag.yml
+      parameters:
+        - name: BRANCH_NAME
+          required: true
+          description: 'Branch used to create a tag for CP-patched branches (for example 2.0.x, 1.14.x). Not intended for hotfix branches.'


### PR DESCRIPTION
This PR adds a semaphore job to create tags in mongo-kafka repo.
We want to create tags in mongo-kafka on PR merges to branches starting from v x.x.x like v2.0.x. This would allow us to have the mongo-kafka-private to checkout submodule using the connect release job - https://confluentinc.atlassian.net/wiki/spaces/IM/pages/5384307136