### PR TITLE
Fix whitelist branches

### DIFF
--- a/.semaphore/project.yml
+++ b/.semaphore/project.yml
@@ -25,7 +25,7 @@ spec:
       branches:
         - master
         - main
-        - /^\d+\.\d+\.x$/
+        - /^v?\d+\.\d+\.x$/
         - /^gh-readonly-queue.*/
   custom_permissions: true
   debug_permissions:


### PR DESCRIPTION
The regex /^\d+\.\d+\.x$/ requires the branch name to start with a digit, so it matches 2.0.x but not v2.0.x (which starts with v). Adding  v to the prefix - /^v?\d+\.\d+\.x$/