### PR TITLE
Uses v2.0.x as the diff base branch for semaphore builds

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -31,7 +31,7 @@ blocks:
     dependencies: []
     run:
       # don't run the tests on non-functional changes...
-      when: "change_in('/', {exclude: ['/.deployed-versions/', '.github/'], default_branch: 'master'})"
+      when: "change_in('/', {exclude: ['/.deployed-versions/', '.github/'], default_branch: 'v2.0.x'})"
     task:
       jobs:
         - name: Test


### PR DESCRIPTION
The build is not running on v2.0.x branch after commits get merged to it. Updating the default branch here as this could be due to:
 change_in can't compute the diff — if the v2.0.x branch has diverged far enough from master, Semaphore may fail to evaluate the condition and default to skipping the block.
 The fix would be to change default_branch to the appropriate base for this branch. Since this is a release branch, change_in should compare against the branch itself (previous commits on v2.0.x), not againstmaster