### PR TITLE
CC-41003: Redact record payloads from sink connector logs

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordData.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordData.java
@@ -107,7 +107,7 @@ final class MongoProcessedSinkRecordData {
       exception = e;
       if (config.logErrors()) {
         LOGGER.error(
-            "Unable to process record in topic:{} at partition:{}, offset:{}",
+            "Unable to process record from {}-{} at offset {}",
             sinkRecord.topic(),
             sinkRecord.kafkaPartition(),
             sinkRecord.kafkaOffset(),

--- a/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
@@ -244,6 +244,12 @@ final class StartedMongoSinkTask implements AutoCloseable {
   }
 
   private static void log(final Collection<SinkRecord> records, final RuntimeException e) {
-    LOGGER.error("Failed to put {} records into the sink", records.size(), e);
+    LOGGER.error(
+        "Failed to put into the sink {} record(s) at offsets {}",
+        records.size(),
+        records.stream()
+            .map(r -> r.topic() + "-" + r.kafkaPartition() + "@" + r.kafkaOffset())
+            .collect(Collectors.toList()),
+        e);
   }
 }


### PR DESCRIPTION
## Summary

Two sink **error-log** sites logged the full `SinkRecord` via its `toString()`, which serializes the record **key, value and headers** — i.e. the customer payload — into the Connect logs. These are exactly the two sites that the connector-specific `logredactor-rules` (`public/prod-connect.rules`) currently redact:

| logredactor rule | Site |
|---|---|
| `MongodbAtlasSink SinkRecord` | `MongoProcessedSinkRecordData` — per-record processing error (`logErrors` path) |
| `MongodbAtlasSink SinkRecord Error` | `StartedMongoSinkTask.log(Collection<SinkRecord>, …)` — batch / DLQ failure funnel |

Each now logs only the Kafka coordinates (`topic-partition@offset`) needed to locate the record, never its contents. An operator can still recover the full record by reading the topic at the logged offset.

Scope is intentionally limited to the two sites the rules target, so once this ships those two rules can be retired. Other DEBUG/TRACE log lines and exception messages in the sink path are **not** covered by any redaction rule and are out of scope here.

## Testing

- `./gradlew compileJava test` for the affected classes passes; spotless clean.

## Follow-up

Once this ships and deploys, retire the two `MongodbAtlasSink` rules from `confluentinc/logredactor-rules` (`public/prod-connect.rules`) in a separate PR.

- JIRA: https://confluentinc.atlassian.net/browse/CC-41003