### PR TITLE
CC-41565/41566/41568/41569: stop leaking Kafka record content into logs

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordData.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordData.java
@@ -106,8 +106,17 @@ final class MongoProcessedSinkRecordData {
     } catch (Exception e) {
       exception = e;
       if (config.logErrors()) {
+        // CC-41565: do not pass the exception object to ERROR - its message (from CDC handlers,
+        // id strategies, etc.) can embed record key/value content. Log only the exception type;
+        // keep the full exception at DEBUG. (See also the sanitized throw-site messages.)
         LOGGER.error(
-            "Unable to process record in topic:{} at partition:{}, offset:{}",
+            "Unable to process record in topic:{} at partition:{}, offset:{}. Cause: {}",
+            sinkRecord.topic(),
+            sinkRecord.kafkaPartition(),
+            sinkRecord.kafkaOffset(),
+            e.getClass().getName());
+        LOGGER.debug(
+            "Unable to process record in topic:{} at partition:{}, offset:{} (full detail)",
             sinkRecord.topic(),
             sinkRecord.kafkaPartition(),
             sinkRecord.kafkaOffset(),

--- a/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
@@ -214,16 +214,32 @@ final class StartedMongoSinkTask implements AutoCloseable {
       final boolean logErrors,
       final boolean tolerateErrors) {
     if (e instanceof MongoBulkWriteException) {
+      MongoBulkWriteException bulkWriteException = (MongoBulkWriteException) e;
       AnalyzedBatchFailedWithBulkWriteException analyzedBatch =
           new AnalyzedBatchFailedWithBulkWriteException(
               batch,
               ordered,
-              (MongoBulkWriteException) e,
+              bulkWriteException,
               errorReporter,
               StartedMongoSinkTask::log);
       if (logErrors) {
+        // CC-41566: never log the driver exception at ERROR - its message embeds record-derived
+        // dup-key values / BSON detail. Log only sanitized metadata (type, codes, counts) here;
+        // keep the full aggregate driver exception at DEBUG.
         LOGGER.error(
+            "Failed to write some records into the sink: {} write error(s) with code(s) {}, "
+                + "{} write concern error(s). Exception: {}",
+            bulkWriteException.getWriteErrors().size(),
+            bulkWriteException.getWriteErrors().stream()
+                .map(writeError -> Integer.toString(writeError.getCode()))
+                .distinct()
+                .collect(Collectors.toList()),
+            bulkWriteException.getWriteConcernError() != null ? 1 : 0,
+            e.getClass().getName());
+        LOGGER.debug(
             "Failed to put into the sink some records, see log entries below for the details", e);
+        // Per-record breakdown: routes through the sanitized log() method below, so each entry is
+        // logged at ERROR without record content (full per-record detail stays at DEBUG).
         analyzedBatch.log();
       }
       if (tolerateErrors) {
@@ -244,6 +260,12 @@ final class StartedMongoSinkTask implements AutoCloseable {
   }
 
   private static void log(final Collection<SinkRecord> records, final RuntimeException e) {
-    LOGGER.error("Failed to put {} records into the sink", records.size(), e);
+    // CC-41566: e (e.g. WriteException) embeds record-derived dup-key / BSON detail in its
+    // message. Log only the count and exception type at ERROR; keep full detail at DEBUG.
+    LOGGER.error(
+        "Failed to put {} records into the sink. Exception: {}",
+        records.size(),
+        e.getClass().getName());
+    LOGGER.debug("Failed to put {} records into the sink (full detail)", records.size(), e);
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/OperationHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/OperationHelper.java
@@ -52,8 +52,8 @@ final class OperationHelper {
     } else if (!changeStreamDocument.get(DOCUMENT_KEY).isDocument()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expecting a document but found `%s`",
-              DOCUMENT_KEY, changeStreamDocument.get(DOCUMENT_KEY)));
+              "Unexpected %s field type, expecting a document but found a value of type `%s`",
+              DOCUMENT_KEY, changeStreamDocument.get(DOCUMENT_KEY).getBsonType()));
     }
 
     return changeStreamDocument.getDocument(DOCUMENT_KEY);
@@ -69,8 +69,8 @@ final class OperationHelper {
     } else if (!changeStreamDocument.get(FULL_DOCUMENT).isDocument()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expecting a document but found `%s`",
-              FULL_DOCUMENT, changeStreamDocument.get(FULL_DOCUMENT)));
+              "Unexpected %s field type, expecting a document but found a value of type `%s`",
+              FULL_DOCUMENT, changeStreamDocument.get(FULL_DOCUMENT).getBsonType()));
     }
 
     return changeStreamDocument.getDocument(FULL_DOCUMENT);
@@ -82,8 +82,8 @@ final class OperationHelper {
     } else if (!changeStreamDocument.get(UPDATE_DESCRIPTION).isDocument()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expected a document found `%s`",
-              UPDATE_DESCRIPTION, changeStreamDocument.get(UPDATE_DESCRIPTION)));
+              "Unexpected %s field type, expected a document but found a value of type `%s`",
+              UPDATE_DESCRIPTION, changeStreamDocument.get(UPDATE_DESCRIPTION).getBsonType()));
     }
 
     BsonDocument updateDescription = changeStreamDocument.getDocument(UPDATE_DESCRIPTION);
@@ -101,8 +101,10 @@ final class OperationHelper {
     } else if (!updateDescription.get(UPDATED_FIELDS).isDocument()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expected a document but found `%s`",
-              UPDATE_DESCRIPTION, updateDescription));
+              "Unexpected %s.%s field type, expected a document but found a value of type `%s`",
+              UPDATE_DESCRIPTION,
+              UPDATED_FIELDS,
+              updateDescription.get(UPDATED_FIELDS).getBsonType()));
     }
 
     if (!updateDescription.containsKey(REMOVED_FIELDS)) {
@@ -110,26 +112,26 @@ final class OperationHelper {
     } else if (!updateDescription.get(REMOVED_FIELDS).isArray()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expected an array but found `%s`",
-              REMOVED_FIELDS, updateDescription.get(REMOVED_FIELDS)));
+              "Unexpected %s field type, expected an array but found a value of type `%s`",
+              REMOVED_FIELDS, updateDescription.get(REMOVED_FIELDS).getBsonType()));
     }
 
     if (updateDescription.containsKey(TRUNCATED_ARRAYS)
         && !updateDescription.get(TRUNCATED_ARRAYS).isArray()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expected an array but found `%s`",
+              "Unexpected %s field type, expected an array but found a value of type `%s`",
               TRUNCATED_ARRAYS,
-              updateDescription.get(TRUNCATED_ARRAYS)));
+              updateDescription.get(TRUNCATED_ARRAYS).getBsonType()));
     }
 
     if (updateDescription.containsKey(DISAMBIGUATED_PATHS)
         && !updateDescription.get(DISAMBIGUATED_PATHS).isDocument()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expected an array but found `%s`",
+              "Unexpected %s field type, expected an array but found a value of type `%s`",
               DISAMBIGUATED_PATHS,
-              updateDescription.get(DISAMBIGUATED_PATHS)));
+              updateDescription.get(DISAMBIGUATED_PATHS).getBsonType()));
     }
 
     BsonDocument updatedFields = updateDescription.getDocument(UPDATED_FIELDS);
@@ -139,8 +141,8 @@ final class OperationHelper {
       if (!removedField.isString()) {
         throw new DataException(
             format(
-                "Unexpected value type in %s, expected an string but found `%s`",
-                REMOVED_FIELDS, removedField));
+                "Unexpected value type in %s, expected a string but found a value of type `%s`",
+                REMOVED_FIELDS, removedField.getBsonType()));
       }
       unsetDocument.append(removedField.asString().getValue(), EMPTY_STRING);
     }

--- a/src/main/java/com/mongodb/kafka/connect/sink/dlq/WriteConcernException.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/dlq/WriteConcernException.java
@@ -21,24 +21,23 @@ import java.util.Locale;
 import com.mongodb.bulk.WriteConcernError;
 
 /**
- * The {@linkplain #getMessage() message} {@linkplain Formatter format} is {@code "v=1, code=%d,
- * codeName=%s, message=%s, details=%s"}, where {@code details} is JSON produced with {@link
- * org.bson.BsonDocument#toJson()}. We may change it in the future, in which case the version
- * (marked with {@code v}) will be incremented.
+ * The {@linkplain #getMessage() message} {@linkplain Formatter format} is {@code "v=2, code=%d,
+ * codeName=%s"}. CC-41566: the driver {@code message} and {@code details} are intentionally
+ * excluded because they can embed record-derived content that must not reach logs. The failing
+ * record itself is still delivered to the dead letter queue. The version (marked with {@code v})
+ * is incremented whenever this format changes.
  */
 public final class WriteConcernException extends NoStackTraceDlqException {
   private static final long serialVersionUID = 1L;
-  private static final int MESSAGE_FORMAT_VERSION = 1;
+  private static final int MESSAGE_FORMAT_VERSION = 2;
 
   public WriteConcernException(final WriteConcernError error) {
     super(
         String.format(
             Locale.ENGLISH,
-            "v=%d, code=%d, codeName=%s, message=%s, details=%s",
+            "v=%d, code=%d, codeName=%s",
             MESSAGE_FORMAT_VERSION,
             error.getCode(),
-            error.getCodeName(),
-            error.getMessage(),
-            error.getDetails().toJson()));
+            error.getCodeName()));
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/dlq/WriteException.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/dlq/WriteException.java
@@ -21,23 +21,19 @@ import java.util.Locale;
 import com.mongodb.WriteError;
 
 /**
- * The {@linkplain #getMessage() message} {@linkplain Formatter format} is {@code "v=1, code=%d,
- * message=%s, details=%s"}, where {@code details} is JSON produced with {@link
- * org.bson.BsonDocument#toJson()}. We may change it in the future, in which case the version
- * (marked with {@code v}) will be incremented.
+ * The {@linkplain #getMessage() message} {@linkplain Formatter format} is {@code "v=2, code=%d"}.
+ * CC-41566: the driver {@code message} and {@code details} are intentionally excluded because they
+ * can embed record-derived content (e.g. duplicate-key values) that must not reach logs - this
+ * exception's message is logged by the Connect framework error reporter when {@code
+ * errors.log.enable=true}. The failing record itself is still delivered to the dead letter queue.
+ * The version (marked with {@code v}) is incremented whenever this format changes.
  */
 public final class WriteException extends NoStackTraceDlqException {
   private static final long serialVersionUID = 1L;
-  private static final int MESSAGE_FORMAT_VERSION = 1;
+  private static final int MESSAGE_FORMAT_VERSION = 2;
 
   public WriteException(final WriteError error) {
     super(
-        String.format(
-            Locale.ENGLISH,
-            "v=%d, code=%d, message=%s, details=%s",
-            MESSAGE_FORMAT_VERSION,
-            error.getCode(),
-            error.getMessage(),
-            error.getDetails().toJson()));
+        String.format(Locale.ENGLISH, "v=%d, code=%d", MESSAGE_FORMAT_VERSION, error.getCode()));
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/TimeseriesTimeFieldAutoConversion.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/TimeseriesTimeFieldAutoConversion.java
@@ -77,10 +77,17 @@ class TimeseriesTimeFieldAutoConversion extends PostProcessor {
     try {
       return Optional.of(supplier.get());
     } catch (Exception e) {
+      // CC-41568: do not log e.getMessage() at INFO - DateTimeParseException embeds the raw
+      // record time-field value. Log only the field name and exception type; keep detail at TRACE.
       LOGGER.info(
+          "Failed to convert field `{}` to a valid date time, so leaving as is. Cause: {}",
+          fieldName,
+          e.getClass().getSimpleName());
+      LOGGER.trace(
           format(
               "Failed to convert field `%s` to a valid date time, so leaving as is: `%s`",
-              fieldName, e.getMessage()));
+              fieldName, e.getMessage()),
+          e);
       return Optional.empty();
     }
   }

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/UuidProvidedStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/UuidProvidedStrategy.java
@@ -50,7 +50,9 @@ abstract class UuidProvidedStrategy extends ProvidedStrategy {
           constructUuidObjectFromString(id.asString().getValue()), UuidRepresentation.STANDARD);
     }
 
-    throw new DataException(format("UUID cannot be constructed from provided value: `%s`", id));
+    // CC-41565: do not embed the raw record value; report only its BSON type.
+    throw new DataException(
+        format("UUID cannot be constructed from a provided value of type `%s`", id.getBsonType()));
   }
 
   private UUID constructUuidObjectFromString(final String uuid) {
@@ -67,6 +69,8 @@ abstract class UuidProvidedStrategy extends ProvidedStrategy {
       // ignore
     }
 
-    throw new DataException(format("UUID cannot be constructed from provided value: `%s`", uuid));
+    // CC-41565: do not embed the raw record string value; report only its length.
+    throw new DataException(
+        format("UUID cannot be constructed from the provided string value (length=%d)", uuid.length()));
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/util/Validators.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/Validators.java
@@ -168,10 +168,15 @@ public final class Validators {
           try {
             consumer.accept((String) value);
           } catch (IllegalArgumentException e){
-            LOGGER.error(e.getMessage());
+            // CC-41569: the driver message can echo URI fragments (host, encoded user info,
+            // scheme). Log a static message at ERROR, keep detail at DEBUG, and throw a redacted
+            // ConfigException with a generic message.
+            LOGGER.error("Invalid {} value: connection string could not be parsed", name);
+            LOGGER.debug("Connection string validation failure detail for {}", name, e);
             throw new ConfigException(name, redactedUrl, connectionUriErrorMessage);
           } catch (Exception e) {
-            throw new ConfigException(name, redactedUrl, e.getMessage());
+            LOGGER.debug("Unexpected error validating {}", name, e);
+            throw new ConfigException(name, redactedUrl, connectionUriErrorMessage);
           }
         }));
   }


### PR DESCRIPTION
# CC-41565/41566/41568/41569: stop leaking Kafka record content into logs

## Summary
Four tickets report Kafka **record key/value content leaking into connector logs** via log
statements and exception messages. This PR sanitizes those paths so only non-sensitive metadata
(field name/path, BSON type, exception type, error codes, counts) reaches INFO/WARN/ERROR; full
detail is retained at DEBUG/TRACE.

**Base branch:** `v2.0.x` (the active release line). The four leak sites are byte-for-byte identical on `v2.0.x` and `v1.16.x` (verified at the same line numbers), so the fix cherry-picks cleanly; affected unit tests pass on `v2.0.x` (45/45). Live before/after evidence below was captured on the shared/identical code.

## Fixes
- **CC-41565 — `MongoProcessedSinkRecordData.tryProcess` (+ CDC/UUID throw sites)**
  - Log the exception **type** at ERROR (not the exception object); full exception at DEBUG.
  - Sanitize the CDC throw-site messages in `OperationHelper` and the `UuidProvidedStrategy`
    messages to report the **BSON type / length**, not the value — so the value is gone even
    when the framework logs the rethrown exception.
- **CC-41566 — `StartedMongoSinkTask`**
  - Drop the driver exception from both `LOGGER.error` calls; log only exception type,
    write-error **code(s)** and **counts**; keep full driver detail at DEBUG.
- **CC-41568 — `TimeseriesTimeFieldAutoConversion`**
  - INFO logs field name + exception simple name; raw `DateTimeParseException` detail at TRACE.
- **CC-41569 — `Validators.errorCheckingPasswordValueValidator`**
  - Static ERROR message (no `connection.uri` fragments); redacted `ConfigException`
    (static message, `[REDACTED URL]`); detail at DEBUG.

## ⚠️ Special mention — DLQ exception-message contract change (beyond the literal suggested fix)
`WriteException` and `WriteConcernException` built `getMessage()` from `error.getMessage()` +
`error.getDetails().toJson()`, which embed record-derived content (e.g. the duplicate-key `_id`).
The Kafka **Connect framework error reporter** logs these exceptions at ERROR when
`errors.log.enable=true` — *outside* the connector's own logging — so the log-site fixes alone
could not stop the `_id` from reaching logs.

**Change:** drop the driver `message`/`details` from both exception messages (keep `code`, and
`codeName` for write-concern); **bump the message format `v1 → v2`**.

Implications:
- DLQ error-**header** message is terser (`v=2, code=11000` instead of the full driver text). The
  failing **record itself is still delivered to the DLQ** unchanged; the error code identifies the
  failure.
- Anyone parsing the old `message=.../details=...` header format should note the `v=2` bump (the
  format Javadoc documents that the version increments on change).
- No unit test depended on the old format (verified).

## Testing
- **Unit tests (JDK 17):** affected suites pass — `cdc.mongodb.operations.*`, `IdStrategyTest`,
  `ValidatorWithOperatorsTest`, `StartedMongoSinkTaskTest`, `MongoSinkRecordProcessorTest`,
  `processor.*` (131/131, then 45/45 incl. DLQ paths).
- **Live end-to-end** against local Kafka Connect + MongoDB Atlas (built from this branch):
  - Reproduced each leak on the unchanged build, then confirmed the marker is **absent from
    connector and framework logs** after the fix.
  - CC-41566 dup-key `_id` now appears **0 times** in the entire log; framework reporter prints
    `WriteException: v=2, code=11000`.
  - Sanitized lines confirm the connector still reports failures (e.g.
    `... write error(s) with code(s) [11000], 0 write concern error(s)`).

## Files changed (8)
`MongoProcessedSinkRecordData.java`, `StartedMongoSinkTask.java`,
`cdc/mongodb/operations/OperationHelper.java`, `processor/TimeseriesTimeFieldAutoConversion.java`,
`processor/id/strategy/UuidProvidedStrategy.java`, `util/Validators.java`,
`sink/dlq/WriteException.java`, `sink/dlq/WriteConcernException.java`

## Before / After — actual captured logs (live repro vs MongoDB Atlas)
Reproduced on the unchanged `v1.16.x` build, then replayed after the fix. Markers are synthetic
test values (`LEAKKEY-*`, `LEAKCHECKHOST`, `LEAKDOCKEY-*`, `not-a-date-*`); the Atlas shard hostname
is redacted as `<atlas-host>`.

### CC-41568 — `TimeseriesTimeFieldAutoConversion` (INFO)
Before:
```
INFO Failed to convert field `sent_in` to a valid date time, so leaving as is: `Text 'not-a-date-123' could not be parsed at index 0` (…sink.processor.PostProcessor)
```
After:
```
INFO Failed to convert field `sent_in` to a valid date time, so leaving as is. Cause: DateTimeParseException (…sink.processor.PostProcessor)
```

### CC-41569 — `Validators` (ERROR; the validation *response* was already redacted)
Before (worker log):
```
ERROR The connection string contains an invalid host 'LEAKCHECKHOST.example.net:NOTAPORT'. The port 'NOTAPORT' is not a valid, it must be an integer between 0 and 65535 (…util.Validators)
```
After (worker log):
```
ERROR Invalid connection.uri value: connection string could not be parsed (…util.Validators)
```
Response (unchanged, both before & after): `Invalid value [REDACTED URL] for configuration connection.uri: Connection string is invalid. …`

### CC-41566 — `StartedMongoSinkTask` (ERROR) + framework error reporter
Before (connector):
```
ERROR Failed to put into the sink some records, see log entries below for the details (…sink.MongoSinkTask)
com.mongodb.MongoBulkWriteException: Bulk write operation error on server <atlas-host>:27017. Write errors: [BulkWriteError{index=1, code=11000, message='E11000 duplicate key error collection: leakdb.cc41566 index: _id_ dup key: { _id: "LEAKKEY-cc41566" }', details={}}].
ERROR Failed to put 1 records into the sink (…sink.MongoSinkTask)
com.mongodb.kafka.connect.sink.dlq.WriteException: v=1, code=11000, message=E11000 duplicate key error collection: leakdb.cc41566 index: _id_ dup key: { _id: "LEAKKEY-cc41566" }, details={}
```
After (connector):
```
ERROR Failed to write some records into the sink: 1 write error(s) with code(s) [11000], 0 write concern error(s). Exception: com.mongodb.MongoBulkWriteException (…sink.MongoSinkTask)
```
After (framework reporter with `errors.log.enable=true` — the residual closed by the `WriteException` v=2 change):
```
ERROR Error encountered in task cc41566-sink-0. Executing stage 'TASK_PUT' with class 'org.apache.kafka.connect.sink.SinkTask'. (org.apache.kafka.connect.runtime.errors.LogReporter)
com.mongodb.kafka.connect.sink.dlq.WriteException: v=2, code=11000
```

### CC-41565 — `MongoProcessedSinkRecordData` (ERROR) + CDC throw-site message
Before (connector ERROR attaches the exception, whose message carries the value):
```
ERROR Unable to process record in topic:cc41565 at partition:0, offset:0 (…sink.MongoProcessedSinkRecordData)
org.apache.kafka.connect.errors.DataException: Unexpected documentKey field type, expecting a document but found `BsonString{value='LEAKDOCKEY-cc41565-SECRET'}`
```
Before (`errors.tolerance=none` also leaks it via the framework):
```
ERROR WorkerSinkTask{id=cc41565-none-0} Task threw an uncaught and unrecoverable exception … Error: Unexpected documentKey field type, expecting a document but found `BsonString{value='LEAKDOCKEY-RETHROW-SECRET'}` (org.apache.kafka.connect.runtime.WorkerSinkTask)
```
After (connector ERROR logs the exception *type* only):
```
ERROR Unable to process record in topic:cc41565 at partition:0, offset:3. Cause: org.apache.kafka.connect.errors.DataException (…sink.MongoProcessedSinkRecordData)
```
After (the exception **message itself** is sanitized → clean even when the framework logs it):
```
org.apache.kafka.connect.errors.DataException: Unexpected documentKey field type, expecting a document but found a value of type `STRING`
```
