### PR TITLE
CC-42191: Backport log-redaction fixes (#110) to v1.16.x

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordData.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordData.java
@@ -107,7 +107,13 @@ final class MongoProcessedSinkRecordData {
       exception = e;
       if (config.logErrors()) {
         LOGGER.error(
-            "Unable to process record in topic:{} at partition:{}, offset:{}",
+            "Unable to process record in topic:{} at partition:{}, offset:{}. Cause: {}",
+            sinkRecord.topic(),
+            sinkRecord.kafkaPartition(),
+            sinkRecord.kafkaOffset(),
+            e.getClass().getName());
+        LOGGER.debug(
+            "Unable to process record in topic:{} at partition:{}, offset:{} (full detail)",
             sinkRecord.topic(),
             sinkRecord.kafkaPartition(),
             sinkRecord.kafkaOffset(),

--- a/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
@@ -214,16 +214,29 @@ final class StartedMongoSinkTask implements AutoCloseable {
       final boolean logErrors,
       final boolean tolerateErrors) {
     if (e instanceof MongoBulkWriteException) {
+      MongoBulkWriteException bulkWriteException = (MongoBulkWriteException) e;
       AnalyzedBatchFailedWithBulkWriteException analyzedBatch =
           new AnalyzedBatchFailedWithBulkWriteException(
               batch,
               ordered,
-              (MongoBulkWriteException) e,
+              bulkWriteException,
               errorReporter,
               StartedMongoSinkTask::log);
       if (logErrors) {
         LOGGER.error(
+            "Failed to write some records into the sink: {} write error(s) with code(s) {}, "
+                + "{} write concern error(s). Exception: {}",
+            bulkWriteException.getWriteErrors().size(),
+            bulkWriteException.getWriteErrors().stream()
+                .map(writeError -> Integer.toString(writeError.getCode()))
+                .distinct()
+                .collect(Collectors.toList()),
+            bulkWriteException.getWriteConcernError() != null ? 1 : 0,
+            e.getClass().getName());
+        LOGGER.debug(
             "Failed to put into the sink some records, see log entries below for the details", e);
+        // Per-record breakdown: routes through the sanitized log() method below, so each entry is
+        // logged at ERROR without record content (full per-record detail stays at DEBUG).
         analyzedBatch.log();
       }
       if (tolerateErrors) {
@@ -244,6 +257,10 @@ final class StartedMongoSinkTask implements AutoCloseable {
   }
 
   private static void log(final Collection<SinkRecord> records, final RuntimeException e) {
-    LOGGER.error("Failed to put {} records into the sink", records.size(), e);
+    LOGGER.error(
+        "Failed to put {} records into the sink. Exception: {}",
+        records.size(),
+        e.getClass().getName());
+    LOGGER.debug("Failed to put {} records into the sink (full detail)", records.size(), e);
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/OperationHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/mongodb/operations/OperationHelper.java
@@ -52,8 +52,8 @@ final class OperationHelper {
     } else if (!changeStreamDocument.get(DOCUMENT_KEY).isDocument()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expecting a document but found `%s`",
-              DOCUMENT_KEY, changeStreamDocument.get(DOCUMENT_KEY)));
+              "Unexpected %s field type, expecting a document but found a value of type `%s`",
+              DOCUMENT_KEY, changeStreamDocument.get(DOCUMENT_KEY).getBsonType()));
     }
 
     return changeStreamDocument.getDocument(DOCUMENT_KEY);
@@ -69,8 +69,8 @@ final class OperationHelper {
     } else if (!changeStreamDocument.get(FULL_DOCUMENT).isDocument()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expecting a document but found `%s`",
-              FULL_DOCUMENT, changeStreamDocument.get(FULL_DOCUMENT)));
+              "Unexpected %s field type, expecting a document but found a value of type `%s`",
+              FULL_DOCUMENT, changeStreamDocument.get(FULL_DOCUMENT).getBsonType()));
     }
 
     return changeStreamDocument.getDocument(FULL_DOCUMENT);
@@ -82,8 +82,8 @@ final class OperationHelper {
     } else if (!changeStreamDocument.get(UPDATE_DESCRIPTION).isDocument()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expected a document found `%s`",
-              UPDATE_DESCRIPTION, changeStreamDocument.get(UPDATE_DESCRIPTION)));
+              "Unexpected %s field type, expected a document but found a value of type `%s`",
+              UPDATE_DESCRIPTION, changeStreamDocument.get(UPDATE_DESCRIPTION).getBsonType()));
     }
 
     BsonDocument updateDescription = changeStreamDocument.getDocument(UPDATE_DESCRIPTION);
@@ -101,8 +101,10 @@ final class OperationHelper {
     } else if (!updateDescription.get(UPDATED_FIELDS).isDocument()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expected a document but found `%s`",
-              UPDATE_DESCRIPTION, updateDescription));
+              "Unexpected %s.%s field type, expected a document but found a value of type `%s`",
+              UPDATE_DESCRIPTION,
+              UPDATED_FIELDS,
+              updateDescription.get(UPDATED_FIELDS).getBsonType()));
     }
 
     if (!updateDescription.containsKey(REMOVED_FIELDS)) {
@@ -110,26 +112,26 @@ final class OperationHelper {
     } else if (!updateDescription.get(REMOVED_FIELDS).isArray()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expected an array but found `%s`",
-              REMOVED_FIELDS, updateDescription.get(REMOVED_FIELDS)));
+              "Unexpected %s field type, expected an array but found a value of type `%s`",
+              REMOVED_FIELDS, updateDescription.get(REMOVED_FIELDS).getBsonType()));
     }
 
     if (updateDescription.containsKey(TRUNCATED_ARRAYS)
         && !updateDescription.get(TRUNCATED_ARRAYS).isArray()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expected an array but found `%s`",
+              "Unexpected %s field type, expected an array but found a value of type `%s`",
               TRUNCATED_ARRAYS,
-              updateDescription.get(TRUNCATED_ARRAYS)));
+              updateDescription.get(TRUNCATED_ARRAYS).getBsonType()));
     }
 
     if (updateDescription.containsKey(DISAMBIGUATED_PATHS)
         && !updateDescription.get(DISAMBIGUATED_PATHS).isDocument()) {
       throw new DataException(
           format(
-              "Unexpected %s field type, expected an array but found `%s`",
+              "Unexpected %s field type, expected an array but found a value of type `%s`",
               DISAMBIGUATED_PATHS,
-              updateDescription.get(DISAMBIGUATED_PATHS)));
+              updateDescription.get(DISAMBIGUATED_PATHS).getBsonType()));
     }
 
     BsonDocument updatedFields = updateDescription.getDocument(UPDATED_FIELDS);
@@ -139,8 +141,8 @@ final class OperationHelper {
       if (!removedField.isString()) {
         throw new DataException(
             format(
-                "Unexpected value type in %s, expected an string but found `%s`",
-                REMOVED_FIELDS, removedField));
+                "Unexpected value type in %s, expected a string but found a value of type `%s`",
+                REMOVED_FIELDS, removedField.getBsonType()));
       }
       unsetDocument.append(removedField.asString().getValue(), EMPTY_STRING);
     }

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/TimeseriesTimeFieldAutoConversion.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/TimeseriesTimeFieldAutoConversion.java
@@ -78,9 +78,14 @@ class TimeseriesTimeFieldAutoConversion extends PostProcessor {
       return Optional.of(supplier.get());
     } catch (Exception e) {
       LOGGER.info(
+          "Failed to convert field `{}` to a valid date time, so leaving as is. Cause: {}",
+          fieldName,
+          e.getClass().getSimpleName());
+      LOGGER.trace(
           format(
               "Failed to convert field `%s` to a valid date time, so leaving as is: `%s`",
-              fieldName, e.getMessage()));
+              fieldName, e.getMessage()),
+          e);
       return Optional.empty();
     }
   }

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/UuidProvidedStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/UuidProvidedStrategy.java
@@ -50,7 +50,8 @@ abstract class UuidProvidedStrategy extends ProvidedStrategy {
           constructUuidObjectFromString(id.asString().getValue()), UuidRepresentation.STANDARD);
     }
 
-    throw new DataException(format("UUID cannot be constructed from provided value: `%s`", id));
+    throw new DataException(
+        format("UUID cannot be constructed from a provided value of type `%s`", id.getBsonType()));
   }
 
   private UUID constructUuidObjectFromString(final String uuid) {
@@ -67,6 +68,7 @@ abstract class UuidProvidedStrategy extends ProvidedStrategy {
       // ignore
     }
 
-    throw new DataException(format("UUID cannot be constructed from provided value: `%s`", uuid));
+    throw new DataException(
+        format("UUID cannot be constructed from the provided string value (length=%d)", uuid.length()));
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/util/Validators.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/Validators.java
@@ -168,10 +168,12 @@ public final class Validators {
           try {
             consumer.accept((String) value);
           } catch (IllegalArgumentException e){
-            LOGGER.error(e.getMessage());
+            LOGGER.error("Invalid {} value: connection string could not be parsed", name);
+            LOGGER.debug("Connection string validation failure detail for {}", name, e);
             throw new ConfigException(name, redactedUrl, connectionUriErrorMessage);
           } catch (Exception e) {
-            throw new ConfigException(name, redactedUrl, e.getMessage());
+            LOGGER.debug("Unexpected error validating {}", name, e);
+            throw new ConfigException(name, redactedUrl, connectionUriErrorMessage);
           }
         }));
   }


### PR DESCRIPTION
## Summary

Backports the log-redaction fixes from **`v2.0.x`** to **`v1.16.x`**.

This is a **straight cherry-pick** of [`#110`](https://github.com/confluentinc/mongo-kafka/pull/110) (commit `4a22d8098`, _"CC-41565/41566/41568/41569: stop leaking Kafka record content into logs"_, by @ssonawane) — applied cleanly with **no conflicts** (6 files, +58/−24). The original commit was authored only against `v2.0.x` and was never back-ported, leaving `v1.16.x` exposed.

## Why

The `v1.16.x` branch still logs Kafka record content / credentials in several places. Each of the JIRAs below maps to a log site that this cherry-pick remediates (sensitive values replaced with bson types / lengths / counts / exception class names; record-bearing detail demoted to DEBUG/TRACE or routed to the DLQ):

- [CC-42185](https://confluentinc.atlassian.net/browse/CC-42185) — `StartedMongoSinkTask` logs full Mongo write-error documents at ERROR
- [CC-42186](https://confluentinc.atlassian.net/browse/CC-42186) — `AnalyzedBatchFailedWithBulkWriteException` dispatches document BSON to the ERROR log
- [CC-42187](https://confluentinc.atlassian.net/browse/CC-42187) — `MongoProcessedSinkRecordData` logs record-derived processing exceptions at ERROR
- [CC-42188](https://confluentinc.atlassian.net/browse/CC-42188) — MongoDB-CDC `OperationHelper` interpolates change-event field values into logged exceptions
- [CC-42189](https://confluentinc.atlassian.net/browse/CC-42189) — `UuidProvidedStrategy` puts the record `_id` value into a logged exception
- [CC-42190](https://confluentinc.atlassian.net/browse/CC-42190) — `TimeseriesTimeFieldAutoConversion` logs the record time-field value at INFO
- [CC-42191](https://confluentinc.atlassian.net/browse/CC-42191) — `Validators` logs the credential-bearing connection URI on parse failure at ERROR

## Source

- Cherry-picked from: [#110](https://github.com/confluentinc/mongo-kafka/pull/110) (`v2.0.x`)
- Cherry-pick recorded with `git cherry-pick -x` (commit message references the original `4a22d8098`).

## Known follow-up (not in this PR)

`#110` deliberately scoped its changes to the log statements. The DLQ exception classes `WriteException` / `WriteConcernException` still embed the failing document's BSON via `error.getDetails().toJson()` in their `getMessage()`, which can surface at DEBUG and in DLQ error headers. This affects **both** `v1.16.x` and `v2.0.x` and is tracked separately under CC-42185 / CC-42186.


[CC-42185]: https://confluentinc.atlassian.net/browse/CC-42185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CC-42186]: https://confluentinc.atlassian.net/browse/CC-42186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CC-42187]: https://confluentinc.atlassian.net/browse/CC-42187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ