### PR TITLE
CC-42186: Sanitize DLQ WriteException/WriteConcernException (drop document BSON details)

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/dlq/WriteConcernException.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/dlq/WriteConcernException.java
@@ -21,24 +21,25 @@ import java.util.Locale;
 import com.mongodb.bulk.WriteConcernError;
 
 /**
- * The {@linkplain #getMessage() message} {@linkplain Formatter format} is {@code "v=1, code=%d,
- * codeName=%s, message=%s, details=%s"}, where {@code details} is JSON produced with {@link
- * org.bson.BsonDocument#toJson()}. We may change it in the future, in which case the version
- * (marked with {@code v}) will be incremented.
+ * The {@linkplain #getMessage() message} {@linkplain Formatter format} is {@code "v=2, code=%d,
+ * codeName=%s, message=%s"}. We may change it in the future, in which case the version (marked with
+ * {@code v}) will be incremented.
+ *
+ * <p>The {@code details} field (BSON of the failing document, previously emitted in {@code v=1}) is
+ * intentionally omitted: it carried record-derived content into the DLQ and into DEBUG logs.
  */
 public final class WriteConcernException extends NoStackTraceDlqException {
   private static final long serialVersionUID = 1L;
-  private static final int MESSAGE_FORMAT_VERSION = 1;
+  private static final int MESSAGE_FORMAT_VERSION = 2;
 
   public WriteConcernException(final WriteConcernError error) {
     super(
         String.format(
             Locale.ENGLISH,
-            "v=%d, code=%d, codeName=%s, message=%s, details=%s",
+            "v=%d, code=%d, codeName=%s, message=%s",
             MESSAGE_FORMAT_VERSION,
             error.getCode(),
             error.getCodeName(),
-            error.getMessage(),
-            error.getDetails().toJson()));
+            error.getMessage()));
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/dlq/WriteException.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/dlq/WriteException.java
@@ -21,23 +21,24 @@ import java.util.Locale;
 import com.mongodb.WriteError;
 
 /**
- * The {@linkplain #getMessage() message} {@linkplain Formatter format} is {@code "v=1, code=%d,
- * message=%s, details=%s"}, where {@code details} is JSON produced with {@link
- * org.bson.BsonDocument#toJson()}. We may change it in the future, in which case the version
- * (marked with {@code v}) will be incremented.
+ * The {@linkplain #getMessage() message} {@linkplain Formatter format} is {@code "v=2, code=%d,
+ * message=%s"}. We may change it in the future, in which case the version (marked with {@code v})
+ * will be incremented.
+ *
+ * <p>The {@code details} field (BSON of the failing document, previously emitted in {@code v=1}) is
+ * intentionally omitted: it carried record-derived content into the DLQ and into DEBUG logs.
  */
 public final class WriteException extends NoStackTraceDlqException {
   private static final long serialVersionUID = 1L;
-  private static final int MESSAGE_FORMAT_VERSION = 1;
+  private static final int MESSAGE_FORMAT_VERSION = 2;
 
   public WriteException(final WriteError error) {
     super(
         String.format(
             Locale.ENGLISH,
-            "v=%d, code=%d, message=%s, details=%s",
+            "v=%d, code=%d, message=%s",
             MESSAGE_FORMAT_VERSION,
             error.getCode(),
-            error.getMessage(),
-            error.getDetails().toJson()));
+            error.getMessage()));
   }
 }


### PR DESCRIPTION
## Summary

Sanitizes the two DLQ exception classes so that the **failing document's BSON is no longer leaked**:

- `WriteException`
- `WriteConcernException`

Both previously embedded `error.getDetails().toJson()` (the failing document's BSON) directly in `getMessage()`. This change drops the `details` field from both message formats and bumps the documented message-format version **1 → 2**. The `code` / `codeName` / `message` fields are retained.

## Why this is needed (the gap #110 left)

[#110](https://github.com/confluentinc/mongo-kafka/pull/110) deliberately scoped its fix to the ERROR **log statements** and explicitly left the DLQ exception classes untouched. As a result the document BSON still escaped via two paths that #110 did not close:

1. **DEBUG logs** — `StartedMongoSinkTask.log()` does `LOGGER.debug("…(full detail)", records.size(), e)`, where `e` is the `WriteException`; its `getMessage()` (with `details=<BSON>`) prints in full at DEBUG.
2. **DLQ error headers** — `AnalyzedBatchFailedWithBulkWriteException.report()` → `errorReporter.report(record, writeException)`, so the exception message (with BSON) lands in the DLQ record's error headers.

## Message-format version bump (reviewer note)

Removing the `details` field is a breaking change to the documented DLQ message contract, so `MESSAGE_FORMAT_VERSION` is bumped `1 → 2` and the javadoc updated — the `v=` marker exists precisely to signal this. Any downstream consumer parsing the `v=1` format (with a trailing `details=…`) should key off the version.

## Scope

- **Drops `details` only.** The driver's `message` string is retained. Note: for duplicate-key errors the driver's `message` can itself echo the conflicting key value — sanitizing that further was considered and intentionally left out of scope for this PR.
- **Tests:** `StartedMongoSinkTaskTest` references these classes by type (`new Report(idx, WriteException.class)`), not by message string, so no test changes were required. (Build/tests not run locally — relying on CI.)

## Related

This is the follow-up flagged on the backport PR [#113](https://github.com/confluentinc/mongo-kafka/pull/113) (which cherry-picked #110 to `v1.16.x`). This PR targets `v2.0.x`; a matching `v1.16.x` change can follow if desired.

### JIRA
- [CC-42185](https://confluentinc.atlassian.net/browse/CC-42185) — `StartedMongoSinkTask` logs full Mongo write-error documents at ERROR (fix rec: drop `details.toJson()` from `WriteException.getMessage()`)
- [CC-42186](https://confluentinc.atlassian.net/browse/CC-42186) — `AnalyzedBatchFailedWithBulkWriteException` dispatches document BSON to the ERROR log (fix rec: strip BSON details from `WriteException.getMessage()`)

Originating work: [#110](https://github.com/confluentinc/mongo-kafka/pull/110).


[CC-42185]: https://confluentinc.atlassian.net/browse/CC-42185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ