### PR TITLE
CC-42848: Stop record-derived data from reaching Connect framework logs (2.0.x)

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordData.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoProcessedSinkRecordData.java
@@ -19,6 +19,7 @@ package com.mongodb.kafka.connect.sink;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -104,7 +105,14 @@ final class MongoProcessedSinkRecordData {
     try {
       return supplier.get();
     } catch (Exception e) {
-      exception = e;
+      LOGGER.trace(
+          "Unable to process record in topic:{} at partition:{}, offset:{}",
+          sinkRecord.topic(),
+          sinkRecord.kafkaPartition(),
+          sinkRecord.kafkaOffset(),
+          e);
+      DataException sanitized = new DataException(e.getMessage());
+      exception = sanitized;
       if (config.logErrors()) {
         LOGGER.error(
             "Unable to process record in topic:{} at partition:{}, offset:{}. Cause: {}",
@@ -120,7 +128,7 @@ final class MongoProcessedSinkRecordData {
             e);
       }
       if (!(config.tolerateErrors() || config.tolerateDataErrors())) {
-        throw e;
+        throw sanitized;
       }
     }
     return Optional.empty();

--- a/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTask.java
@@ -167,7 +167,9 @@ final class StartedMongoSinkTask implements AutoCloseable {
       statistics.getBatchWritesFailed().sample(writeTime.getElapsedTime().toMillis());
       statistics.getRecordsFailed().sample(batch.size());
       if (config.tolerateDataErrors() && !(e instanceof MongoBulkWriteException)) {
-        throw new DataException("non Data Error, fail the connector.", e);
+        LOGGER.trace("non Data Error, failing the connector", e);
+        throw new DataException(
+            "non Data Error, fail the connector. Exception type: " + e.getClass().getName());
       }
       handleTolerableWriteException(
           batch.stream()
@@ -215,6 +217,7 @@ final class StartedMongoSinkTask implements AutoCloseable {
       final boolean tolerateErrors) {
     if (e instanceof MongoBulkWriteException) {
       MongoBulkWriteException bulkWriteException = (MongoBulkWriteException) e;
+      LOGGER.trace("Failed to write some records into the sink", bulkWriteException);
       AnalyzedBatchFailedWithBulkWriteException analyzedBatch =
           new AnalyzedBatchFailedWithBulkWriteException(
               batch,
@@ -242,16 +245,30 @@ final class StartedMongoSinkTask implements AutoCloseable {
       if (tolerateErrors) {
         analyzedBatch.report();
       } else {
-        throw new DataException(e);
+        throw new DataException(
+            String.format(
+                "Failed to write some records into the sink: %d write error(s) with code(s) %s, "
+                    + "%d write concern error(s)",
+                bulkWriteException.getWriteErrors().size(),
+                bulkWriteException.getWriteErrors().stream()
+                    .map(writeError -> Integer.toString(writeError.getCode()))
+                    .distinct()
+                    .collect(Collectors.toList()),
+                bulkWriteException.getWriteConcernError() != null ? 1 : 0));
       }
     } else {
+      LOGGER.trace("Failed to write records into the sink", e);
       if (logErrors) {
         log(batch, e);
       }
       if (tolerateErrors) {
-        batch.forEach(record -> errorReporter.report(record, e));
+        DataException sanitized =
+            new DataException(
+                "Failed to write records into the sink. Exception type: " + e.getClass().getName());
+        batch.forEach(record -> errorReporter.report(record, sanitized));
       } else {
-        throw new DataException(e);
+        throw new DataException(
+            "Failed to write records into the sink. Exception type: " + e.getClass().getName());
       }
     }
   }

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbUpdate.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbUpdate.java
@@ -66,7 +66,8 @@ public class MongoDbUpdate implements CdcOperation {
     } catch (DataException exc) {
       throw exc;
     } catch (Exception exc) {
-      throw new DataException(exc.getMessage(), exc);
+      throw new DataException(
+          "Unable to process update event. Exception type: " + exc.getClass().getName());
     }
   }
 

--- a/src/main/java/com/mongodb/kafka/connect/sink/dlq/AnalyzedBatchFailedWithBulkWriteException.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/dlq/AnalyzedBatchFailedWithBulkWriteException.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.stream.IntStream;
 
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.slf4j.LoggerFactory;
 
 import com.mongodb.MongoBulkWriteException;
 import com.mongodb.bulk.BulkWriteError;
@@ -41,6 +42,8 @@ import com.mongodb.lang.Nullable;
  * MongoBulkWriteException}.
  */
 public final class AnalyzedBatchFailedWithBulkWriteException {
+  private static final org.slf4j.Logger SLF4J_LOGGER =
+      LoggerFactory.getLogger(AnalyzedBatchFailedWithBulkWriteException.class);
   private final List<SinkRecord> batch;
   private final MongoBulkWriteException e;
   private final ErrorReporter errorReporter;
@@ -63,6 +66,14 @@ public final class AnalyzedBatchFailedWithBulkWriteException {
     this.errorReporter = errorReporter;
     this.logger = logger;
     WriteConcernError writeConcernError = e.getWriteConcernError();
+    if (writeConcernError != null) {
+      SLF4J_LOGGER.trace(
+          "Write concern error: code={}, codeName={}, message={}, details={}",
+          writeConcernError.getCode(),
+          writeConcernError.getCodeName(),
+          writeConcernError.getMessage(),
+          writeConcernError.getDetails().toJson());
+    }
     writeConcernException =
         writeConcernError == null ? null : new WriteConcernException(writeConcernError);
     analyze(ordered);
@@ -75,6 +86,12 @@ public final class AnalyzedBatchFailedWithBulkWriteException {
     writeErrors.forEach(
         writeError -> {
           int writeErrorIdx = writeError.getIndex();
+          SLF4J_LOGGER.trace(
+              "Write error for record index {}: code={}, message={}, details={}",
+              writeErrorIdx,
+              writeError.getCode(),
+              writeError.getMessage(),
+              writeError.getDetails().toJson());
           recordsFailedWithWriteError.put(
               writeErrorIdx,
               new AbstractMap.SimpleImmutableEntry<>(

--- a/src/main/java/com/mongodb/kafka/connect/sink/dlq/WriteConcernException.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/dlq/WriteConcernException.java
@@ -21,24 +21,22 @@ import java.util.Locale;
 import com.mongodb.bulk.WriteConcernError;
 
 /**
- * The {@linkplain #getMessage() message} {@linkplain Formatter format} is {@code "v=1, code=%d,
- * codeName=%s, message=%s, details=%s"}, where {@code details} is JSON produced with {@link
- * org.bson.BsonDocument#toJson()}. We may change it in the future, in which case the version
- * (marked with {@code v}) will be incremented.
+ * The {@linkplain #getMessage() message} {@linkplain Formatter format} is {@code "v=2, code=%d,
+ * codeName=%s"}. {@link WriteConcernError#getMessage()}/{@link WriteConcernError#getDetails()}
+ * are omitted since they embed record field values. We may change the format again in the
+ * future, in which case the version (marked with {@code v}) will be incremented.
  */
 public final class WriteConcernException extends NoStackTraceDlqException {
   private static final long serialVersionUID = 1L;
-  private static final int MESSAGE_FORMAT_VERSION = 1;
+  private static final int MESSAGE_FORMAT_VERSION = 2;
 
   public WriteConcernException(final WriteConcernError error) {
     super(
         String.format(
             Locale.ENGLISH,
-            "v=%d, code=%d, codeName=%s, message=%s, details=%s",
+            "v=%d, code=%d, codeName=%s",
             MESSAGE_FORMAT_VERSION,
             error.getCode(),
-            error.getCodeName(),
-            error.getMessage(),
-            error.getDetails().toJson()));
+            error.getCodeName()));
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/dlq/WriteException.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/dlq/WriteException.java
@@ -21,23 +21,21 @@ import java.util.Locale;
 import com.mongodb.WriteError;
 
 /**
- * The {@linkplain #getMessage() message} {@linkplain Formatter format} is {@code "v=1, code=%d,
- * message=%s, details=%s"}, where {@code details} is JSON produced with {@link
- * org.bson.BsonDocument#toJson()}. We may change it in the future, in which case the version
- * (marked with {@code v}) will be incremented.
+ * The {@linkplain #getMessage() message} {@linkplain Formatter format} is {@code "v=2, code=%d"}.
+ * {@link WriteError#getMessage()}/{@link WriteError#getDetails()} are omitted since they embed
+ * record field values (e.g. {@code dup key: {...}}). We may change the format again in the
+ * future, in which case the version (marked with {@code v}) will be incremented.
  */
 public final class WriteException extends NoStackTraceDlqException {
   private static final long serialVersionUID = 1L;
-  private static final int MESSAGE_FORMAT_VERSION = 1;
+  private static final int MESSAGE_FORMAT_VERSION = 2;
 
   public WriteException(final WriteError error) {
     super(
         String.format(
             Locale.ENGLISH,
-            "v=%d, code=%d, message=%s, details=%s",
+            "v=%d, code=%d",
             MESSAGE_FORMAT_VERSION,
-            error.getCode(),
-            error.getMessage(),
-            error.getDetails().toJson()));
+            error.getCode()));
   }
 }

--- a/src/test/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTaskTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/StartedMongoSinkTaskTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -191,13 +192,35 @@ final class StartedMongoSinkTaskTest {
             asList(0, 1, 2),
             asList(
                 // batch1
-                new Report(0, MongoCommandException.class),
-                new Report(1, MongoCommandException.class),
+                new Report(0, DataException.class),
+                new Report(1, DataException.class),
                 // batch2
-                new Report(2, MongoCommandException.class)));
+                new Report(2, DataException.class)));
     task.put(recordsAndExpectations.records());
     recordsAndExpectations.assertExpectations(
         client.capturedBulkWrites().get(DEFAULT_NAMESPACE), errorReporter.reported());
+  }
+
+  @Test
+  void putTolerateAllAnyErrorDoesNotLeakRecordDataViaReport() {
+    String sensitiveMessage = "Invalid BSON field name: dup key { memberCode: \"1234567890\" }";
+    properties.put(MongoSinkTopicConfig.ERRORS_TOLERANCE_CONFIG, ErrorTolerance.ALL.value());
+    MongoSinkConfig config = new MongoSinkConfig(properties);
+    client.configureCapturing(
+        DEFAULT_NAMESPACE,
+        collection ->
+            when(collection.bulkWrite(anyList(), any(BulkWriteOptions.class)))
+                .thenThrow(new IllegalArgumentException(sensitiveMessage)));
+    task = new StartedMongoSinkTask(config, client.mongoClient(), errorReporter);
+
+    task.put(singletonList(Records.simpleValid(TEST_TOPIC, 0)));
+
+    assertEquals(1, errorReporter.reported().size());
+    Throwable reported = errorReporter.reported().get(0).exception();
+    assertEquals(DataException.class, reported.getClass());
+    assertFalse(reported.getMessage().contains("1234567890"));
+    assertFalse(reported.getMessage().contains("memberCode"));
+    assertNull(reported.getCause());
   }
 
   @Test
@@ -239,6 +262,45 @@ final class StartedMongoSinkTaskTest {
     assertThrows(DataException.class, () -> task.put(recordsAndExpectations.records()));
     recordsAndExpectations.assertExpectations(
         client.capturedBulkWrites().get(DEFAULT_NAMESPACE), errorReporter.reported());
+  }
+
+  @Test
+  void putTolerateNoneWriteErrorDoesNotLeakRecordDataUncaught() {
+    String sensitiveMessage =
+        "E11000 duplicate key error collection: UMV.MemberAdditionalDetails index: memberCode_1 "
+            + "dup key: { memberCode: \"1234567890\" }";
+    MongoSinkConfig config = new MongoSinkConfig(properties);
+    client.configureCapturing(
+        DEFAULT_NAMESPACE,
+        collection ->
+            when(collection.bulkWrite(anyList(), any(BulkWriteOptions.class)))
+                .thenThrow(
+                    new MongoBulkWriteException(
+                        BulkWriteResult.unacknowledged(),
+                        singletonList(
+                            new BulkWriteError(
+                                11000,
+                                sensitiveMessage,
+                                BsonDocument.parse("{\"memberCode\": \"1234567890\"}"),
+                                0)),
+                        null,
+                        new ServerAddress(),
+                        emptySet())));
+    task = new StartedMongoSinkTask(config, client.mongoClient(), errorReporter);
+
+    DataException thrown =
+        assertThrows(
+            DataException.class,
+            () -> task.put(singletonList(Records.simpleValid(TEST_TOPIC, 0))));
+
+    assertFalse(thrown.getMessage().contains("1234567890"));
+    assertFalse(thrown.getMessage().contains("memberCode"));
+    assertFalse(thrown.getMessage().contains("dup key"));
+    assertNull(
+        thrown.getCause(),
+        "cause must not chain the raw MongoBulkWriteException, whose getMessage() is not "
+            + "controlled by this connector and would still be rendered in WorkerSinkTask's "
+            + "stack trace logging even if the DataException's own message is safe");
   }
 
   @Test

--- a/src/test/java/com/mongodb/kafka/connect/sink/dlq/WriteConcernExceptionTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/dlq/WriteConcernExceptionTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.kafka.connect.sink.dlq;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import org.bson.BsonDocument;
+
+import com.mongodb.bulk.WriteConcernError;
+
+/** {@link WriteConcernException#getMessage()} must never embed the server's raw error text. */
+final class WriteConcernExceptionTest {
+
+  private static final String SENSITIVE_MESSAGE =
+      "waiting for replication timed out for document with _id: \"customer-42\"";
+
+  @Test
+  void messageExcludesServerErrorTextAndDetails() {
+    WriteConcernError error =
+        new WriteConcernError(
+            64,
+            "WriteConcernFailed",
+            SENSITIVE_MESSAGE,
+            BsonDocument.parse("{\"_id\": \"customer-42\"}"));
+
+    WriteConcernException exception = new WriteConcernException(error);
+
+    assertFalse(
+        exception.getMessage().contains("customer-42"),
+        "message must not contain the record's identifier value");
+    assertFalse(
+        exception.getMessage().contains("waiting for replication"),
+        "message must not contain the raw MongoDB server error text");
+  }
+
+  @Test
+  void messageStillCarriesCodeAndCodeNameForTriage() {
+    WriteConcernError error =
+        new WriteConcernError(64, "WriteConcernFailed", SENSITIVE_MESSAGE, BsonDocument.parse("{}"));
+
+    WriteConcernException exception = new WriteConcernException(error);
+
+    assertTrue(exception.getMessage().contains("code=64"));
+    assertTrue(exception.getMessage().contains("codeName=WriteConcernFailed"));
+  }
+
+  @Test
+  void messageFormatVersionWasBumped() {
+    WriteConcernError error =
+        new WriteConcernError(64, "WriteConcernFailed", SENSITIVE_MESSAGE, BsonDocument.parse("{}"));
+
+    WriteConcernException exception = new WriteConcernException(error);
+
+    assertEquals("v=2, code=64, codeName=WriteConcernFailed", exception.getMessage());
+  }
+}

--- a/src/test/java/com/mongodb/kafka/connect/sink/dlq/WriteExceptionTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/dlq/WriteExceptionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.kafka.connect.sink.dlq;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import org.bson.BsonDocument;
+
+import com.mongodb.WriteError;
+
+/** {@link WriteException#getMessage()} must never embed the server's raw write-error text. */
+final class WriteExceptionTest {
+
+  private static final String SENSITIVE_MESSAGE =
+      "E11000 duplicate key error collection: UMV.MemberAdditionalDetails index: memberCode_1 "
+          + "dup key: { memberCode: \"1234567890\" }";
+
+  @Test
+  void messageExcludesServerErrorTextAndDetails() {
+    WriteError error =
+        new WriteError(
+            11000, SENSITIVE_MESSAGE, BsonDocument.parse("{\"memberCode\": \"1234567890\"}"));
+
+    WriteException exception = new WriteException(error);
+
+    assertFalse(
+        exception.getMessage().contains("1234567890"),
+        "message must not contain the record's business-key value");
+    assertFalse(
+        exception.getMessage().contains("memberCode"),
+        "message must not contain the record's field name/value from the server error text");
+    assertFalse(
+        exception.getMessage().contains("dup key"),
+        "message must not contain the raw MongoDB server error text");
+  }
+
+  @Test
+  void messageStillCarriesTheErrorCodeForTriage() {
+    WriteError error = new WriteError(11000, SENSITIVE_MESSAGE, BsonDocument.parse("{}"));
+
+    WriteException exception = new WriteException(error);
+
+    assertTrue(exception.getMessage().contains("code=11000"));
+  }
+
+  @Test
+  void messageFormatVersionWasBumped() {
+    WriteError error = new WriteError(11000, SENSITIVE_MESSAGE, BsonDocument.parse("{}"));
+
+    WriteException exception = new WriteException(error);
+
+    assertEquals("v=2, code=11000", exception.getMessage());
+  }
+}


### PR DESCRIPTION
https://github.com/confluentinc/mongo-kafka/pull/115